### PR TITLE
chore: configure backend linting and formatting (flake8 + black)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+exclude =
+    venv,
+    __pycache__,
+    migrations

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,14 @@
+# File: backend/models.py
+# Purpose: Defines SQLAlchemy models for Hero Tournament Manager.
+# Models:
+# - Event: Tournament event (name, date, rules, status)
+# - Entrant: Player/character registered in an event
+# - Match: A match within an event, with entrants, round, scores, winner
+
 from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
+
 
 class Event(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -11,11 +19,13 @@ class Event(db.Model):
     entrants = db.relationship("Entrant", backref="event", lazy=True)
     matches = db.relationship("Match", backref="event", lazy=True)
 
+
 class Entrant(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String, nullable=False)
     alias = db.Column(db.String)
     event_id = db.Column(db.Integer, db.ForeignKey("event.id"), nullable=False)
+
 
 class Match(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+from flask import Flask
+from backend.models import db
+
+@pytest.fixture(scope="session")
+def app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.drop_all()
+
+@pytest.fixture
+def session(app):
+    with app.app_context():
+        yield db.session
+        db.session.rollback()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,13 @@
+# File: backend/tests/conftest.py
+# Purpose: Global pytest fixtures for backend tests.
+# Provides:
+# - app: Flask app configured with in-memory SQLite DB
+# - session: SQLAlchemy session scoped to test context
+
 import pytest
 from flask import Flask
 from backend.models import db
+
 
 @pytest.fixture(scope="session")
 def app():
@@ -13,6 +20,7 @@ def app():
         db.create_all()
         yield app
         db.drop_all()
+
 
 @pytest.fixture
 def session(app):

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,26 +1,68 @@
-import pytest
+# File: backend/tests/test_models.py
+# Purpose: Unit tests for Event, Entrant, and Match models.
+# Notes:
+# - Uses pytest with fixtures defined in backend/tests/conftest.py
+# - Runs against an in-memory SQLite database for speed & isolation
+
 from backend.models import Event, Entrant, Match
 
+
 def test_create_event(session):
-    event = Event(name="Hero Cup", date="2025-09-12", rules="Bo3", status="open")
+    event = Event(
+        name="Hero Cup",
+        date="2025-09-12",
+        rules="Bo3",
+        status="open",
+    )
     session.add(event)
     session.commit()
     assert event.id is not None
     assert event.name == "Hero Cup"
 
+
 def test_create_entrant_with_event(session):
-    event = Event(name="Hero Cup", date="2025-09-12", rules="Bo3", status="open")
-    entrant = Entrant(name="Spiderman", alias="Webslinger", event=event)
+    event = Event(
+        name="Hero Cup",
+        date="2025-09-12",
+        rules="Bo3",
+        status="open",
+    )
+    entrant = Entrant(
+        name="Spiderman",
+        alias="Webslinger",
+        event=event,
+    )
     session.add_all([event, entrant])
     session.commit()
     assert entrant.id is not None
     assert entrant.event == event
 
+
 def test_create_match_with_event_and_entrants(session):
-    event = Event(name="Hero Cup", date="2025-09-12", rules="Bo3", status="open")
-    entrant1 = Entrant(name="Spiderman", alias="Webslinger", event=event)
-    entrant2 = Entrant(name="Venom", alias="Symbiote", event=event)
-    match = Match(event=event, round=1, entrant1_id=1, entrant2_id=2, scores="2-1", winner_id=1)
+    event = Event(
+        name="Hero Cup",
+        date="2025-09-12",
+        rules="Bo3",
+        status="open",
+    )
+    entrant1 = Entrant(
+        name="Spiderman",
+        alias="Webslinger",
+        event=event,
+    )
+    entrant2 = Entrant(
+        name="Venom",
+        alias="Symbiote",
+        event=event,
+    )
+    match = Match(
+        event=event,
+        round=1,
+        entrant1_id=1,
+        entrant2_id=2,
+        scores="2-1",
+        winner_id=1,
+    )
     session.add_all([event, entrant1, entrant2, match])
     session.commit()
     assert match.id is not None

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,28 @@
+import pytest
+from backend.models import Event, Entrant, Match
+
+def test_create_event(session):
+    event = Event(name="Hero Cup", date="2025-09-12", rules="Bo3", status="open")
+    session.add(event)
+    session.commit()
+    assert event.id is not None
+    assert event.name == "Hero Cup"
+
+def test_create_entrant_with_event(session):
+    event = Event(name="Hero Cup", date="2025-09-12", rules="Bo3", status="open")
+    entrant = Entrant(name="Spiderman", alias="Webslinger", event=event)
+    session.add_all([event, entrant])
+    session.commit()
+    assert entrant.id is not None
+    assert entrant.event == event
+
+def test_create_match_with_event_and_entrants(session):
+    event = Event(name="Hero Cup", date="2025-09-12", rules="Bo3", status="open")
+    entrant1 = Entrant(name="Spiderman", alias="Webslinger", event=event)
+    entrant2 = Entrant(name="Venom", alias="Symbiote", event=event)
+    match = Match(event=event, round=1, entrant1_id=1, entrant2_id=2, scores="2-1", winner_id=1)
+    session.add_all([event, entrant1, entrant2, match])
+    session.commit()
+    assert match.id is not None
+    assert match.round == 1
+    assert match.scores == "2-1"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,12 @@
         "react-dom": "^19.1.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.35.0",
+        "eslint": "^8.57.1",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.4.20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2435,12 +2441,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
+      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -7249,6 +7259,18 @@
         "eslint": "^8.0.0"
       }
     },
+    "node_modules/eslint-config-react-app/node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -7462,15 +7484,26 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.20.tgz",
+      "integrity": "sha512-XpbHQ2q5gUF8BGOX4dHe+71qoirYMhApEPZ7sfhF/dNnOF1UXnCMGZf79SFTBO7Bz5YEIT4TMieSlJBWhP9WBA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -7606,6 +7639,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint/node_modules/argparse": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx"
   },
   "eslintConfig": {
     "extends": [
@@ -35,5 +36,11 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.35.0",
+    "eslint": "^8.57.1",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+"scripts": {
+  "lint:backend": "flake8 backend",
+  "format:backend": "black backend"
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,16 @@
-"scripts": {
-  "lint:backend": "flake8 backend",
-  "format:backend": "black backend"
+{
+  "name": "hero-tournament-manager",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "lint:backend": "flake8 backend",
+    "format:backend": "black backend",
+    "fix:backend": "black backend && flake8 backend",
+    "lint:frontend": "cd frontend && npm run lint",
+    "test:backend": "pytest -q --disable-warnings",
+    "test:frontend": "cd frontend && npm test",
+    "start:frontend": "cd frontend && npm start",
+    "test": "npm run test:backend && npm run test:frontend"
+  },
+  "devDependencies": {}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.pytest.ini_options]
+pythonpath = [
+  ".",          # root of repo
+  "backend",    # so `backend.models` resolves cleanly
+]
+testpaths = [
+  "backend/tests",
+]
+
+[tool.black]
+line-length = 88
+target-version = ["py313"]
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.git
+    | \.venv
+    | build
+    | dist
+    | migrations
+  )/
+)
+'''

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = backend/tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+-r backend/requirements.txt
+pytest
+
+# Dev-only tools
+flake8==7.1.1
+black==24.8.0


### PR DESCRIPTION
### Summary
Adds linting and formatting tools for the backend to ensure consistent code style and easier maintenance.

### Changes
- Added `flake8` for linting
- Added `black` for auto-formatting
- Updated root `package.json` with scripts:
  - `lint:backend` → run flake8
  - `format:backend` → run black
  - `fix:backend` → run black then flake8 in one step
- Created `requirements-dev.txt` to track dev-only dependencies

### Notes
- Run `npm run fix:backend` to auto-format with Black and then lint with Flake8 in a single step
- Running `npm test` will continue to run both backend and frontend test suites
