### PR TITLE
feat: add Event CRUD routes with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,34 @@ pip install -r requirements-dev.txt
 
 ## Running Tests
 ### Backend Tests
+Run directly:
+
 ```
 cd backend
 pytest -v
 ```
 
+Or via npm script:
+```
+npm run test:backend
+```
+This runs both model tests and API route tests (CRUD for Events) against an in-memory SQLite database.
+
 ### Frontend Tests
+Run directly:
+
 ```
 cd frontend
+npm test
+```
+
+Or via npm script:
+```
+npm run test:frontend
+```
+
+### Full Suite (backend + frontend)
+```
 npm test
 ```
 
@@ -144,13 +164,19 @@ hero-tournament-manager/
 │   ├── config.py
 │   ├── models.py
 │   ├── routes/
-│   ├── migrations/
+│   │   └── events.py
+│   ├── tests/
+│   │   ├── conftest.py
+│   │   ├── test_models.py
+│   │   └── test_routes_events.py
 │   └── requirements.txt
 ├── frontend/
 │   ├── package.json
 │   ├── public/
 │   └── src/
 ├── venv/
+├── requirements-dev.txt
+├── package.json
 ├── README.md
 └── LICENSE
 ```

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,27 @@
+# File: backend/app.py
+# Purpose: Flask application entry point.
+# Notes:
+# - Initializes Flask app and SQLAlchemy.
+# - Registers Blueprints for API routes.
+
+from flask import Flask
+from backend.models import db
+from backend.routes.events import bp as events_bp
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///tournaments.db"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    db.init_app(app)
+
+    # Register Blueprints
+    app.register_blueprint(events_bp)
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    app.run(port=5500, debug=True)

--- a/backend/routes/events.py
+++ b/backend/routes/events.py
@@ -1,0 +1,61 @@
+# File: backend/routes/events.py
+# Purpose: Defines Flask Blueprint for Event CRUD routes.
+# Notes:
+# - Supports create, read (list), update, and delete.
+# - Uses SQLAlchemy models from backend.models.
+# - Returns JSON responses with appropriate status codes.
+# - Mounted under `/events` via url_prefix in Blueprint.
+
+from flask import Blueprint, request, jsonify
+from backend.models import db, Event
+
+bp = Blueprint("events", __name__, url_prefix="/events")
+
+
+@bp.route("", methods=["POST"])
+def create_event():
+    """Create a new Event."""
+    data = request.get_json()
+    event = Event(
+        name=data.get("name"),
+        date=data.get("date"),
+        rules=data.get("rules"),
+        status=data.get("status"),
+    )
+    db.session.add(event)
+    db.session.commit()
+    return jsonify({"id": event.id, "name": event.name, "status": event.status}), 201
+
+
+@bp.route("", methods=["GET"])
+def get_events():
+    """Retrieve all Events."""
+    events = Event.query.all()
+    return jsonify(
+        [
+            {"id": e.id, "name": e.name, "date": e.date, "rules": e.rules, "status": e.status}
+            for e in events
+        ]
+    ), 200
+
+
+@bp.route("/<int:event_id>", methods=["PUT"])
+def update_event(event_id):
+    """Update an Event by ID."""
+    event = Event.query.get_or_404(event_id)
+    data = request.get_json()
+    for key, value in data.items():
+        setattr(event, key, value)
+    db.session.commit()
+    return jsonify(
+        {"id": event.id, "name": event.name, "date": event.date, "rules": event.rules, "status": event.status}
+    ), 200
+
+
+@bp.route("/<int:event_id>", methods=["DELETE"])
+def delete_event(event_id):
+    """Delete an Event by ID."""
+    event = Event.query.get_or_404(event_id)
+    db.session.delete(event)
+    db.session.commit()
+    return "", 204

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,20 +1,21 @@
 # File: backend/tests/conftest.py
 # Purpose: Global pytest fixtures for backend tests.
 # Provides:
-# - app: Flask app configured with in-memory SQLite DB
+# - app: Flask app created via factory (uses in-memory SQLite)
+# - client: Flask test client for API requests
 # - session: SQLAlchemy session scoped to test context
 
 import pytest
-from flask import Flask
+from backend.app import create_app
 from backend.models import db
 
 
 @pytest.fixture(scope="session")
 def app():
-    app = Flask(__name__)
+    """Create a Flask app instance for testing with in-memory DB."""
+    app = create_app()
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-    db.init_app(app)
+    app.config["TESTING"] = True
 
     with app.app_context():
         db.create_all()
@@ -23,13 +24,14 @@ def app():
 
 
 @pytest.fixture
-def session(app):
-    with app.app_context():
-        yield db.session
-        db.session.rollback()
+def client(app):
+    """Provide Flask test client for making requests."""
+    return app.test_client()
 
 
 @pytest.fixture
-def client(app):
-    """Fixture for Flask test client to send simulated HTTP requests."""
-    return app.test_client()
+def session(app):
+    """Provide SQLAlchemy session for direct DB access in tests."""
+    with app.app_context():
+        yield db.session
+        db.session.rollback()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -27,3 +27,9 @@ def session(app):
     with app.app_context():
         yield db.session
         db.session.rollback()
+
+
+@pytest.fixture
+def client(app):
+    """Fixture for Flask test client to send simulated HTTP requests."""
+    return app.test_client()

--- a/backend/tests/test_routes_events.py
+++ b/backend/tests/test_routes_events.py
@@ -1,0 +1,65 @@
+# File: backend/tests/test_routes_events.py
+# Purpose: API route tests for Event resource (CRUD).
+# Notes:
+# - Uses Flask test client fixture (`client`) defined in conftest.py.
+# - Covers create, read, update, delete operations for Event.
+# - Runs against an in-memory SQLite database for isolation.
+
+import pytest
+from backend.models import Event, db
+
+
+def test_create_event(client):
+    response = client.post(
+        "/events",
+        json={"name": "Hero Cup", "date": "2025-09-12", "rules": "Bo3", "status": "open"},
+    )
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["name"] == "Hero Cup"
+    assert data["status"] == "open"
+
+
+def test_get_events(client):
+    # Arrange: create a seed event
+    event = Event(name="Seed Event", date="2025-01-01", rules="Bo1", status="open")
+    db.session.add(event)
+    db.session.commit()
+
+    # Act: call endpoint
+    response = client.get("/events")
+
+    # Assert
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert any(ev["name"] == "Seed Event" for ev in data)
+
+
+def test_update_event(client):
+    # Arrange: create an event
+    event = Event(name="Temp Event", status="open")
+    db.session.add(event)
+    db.session.commit()
+
+    # Act: update status
+    response = client.put(f"/events/{event.id}", json={"status": "closed"})
+
+    # Assert
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "closed"
+
+
+def test_delete_event(client):
+    # Arrange: create an event
+    event = Event(name="Delete Me", status="open")
+    db.session.add(event)
+    db.session.commit()
+
+    # Act: delete it
+    response = client.delete(f"/events/{event.id}")
+
+    # Assert
+    assert response.status_code == 204
+    assert Event.query.get(event.id) is None


### PR DESCRIPTION
### Summary
Implements Event CRUD API routes with full test coverage and updates documentation.

### What's New
- Added `backend/routes/events.py` with create, list, update, and delete endpoints
- Registered routes via blueprint in `backend/app.py`
- Updated pytest fixtures in `conftest.py` to use `create_app()` and provide `client`
- Added route tests in `test_routes_events.py` (now passing)
- Updated README with backend testing instructions and npm scripts

### Next Steps
- Add Entrant and Match CRUD routes with similar TDD workflow
- Expand test coverage to edge cases (invalid data, missing fields)
- Begin wiring frontend to these endpoints
