### PR TITLE
Polish: Add lint/format tooling and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ npm run lint:frontend
 ```
 npm run format:frontend
 ```
+- **One-step fix (format then lint):**
+```
+npm run fix:frontend
+```
 These commands use [ESLint](https://eslint.org/) for linting and [Prettier](https://prettier.io/) for formatting.
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ npm start
 ---
 
 ## Development Tools
-
 ### Backend Linting & Formatting
 - **Lint (check code style):**
 ```
@@ -101,6 +100,17 @@ npm run fix:backend
 ```
 These commands use [Flake8](https://flake8.pycqa.org/) for linting and [Black](https://black.readthedocs.io/) for auto-formatting.
 
+### Frontend Linting & Formatting
+- **Lint (check code style):**
+```
+npm run lint:frontend
+```
+- **Format (auto-fix code style):**
+```
+npm run format:frontend
+```
+These commands use [ESLint](https://eslint.org/) for linting and [Prettier](https://prettier.io/) for formatting.
+
 ### Requirements
 - Standard dependencies are in `backend/requirements.txt`
 - Dev-only dependencies (linting, formatting, pytest) are in `requirements-dev.txt`
@@ -109,6 +119,24 @@ Install both when working locally:
 ```
 pip install -r backend/requirements.txt
 pip install -r requirements-dev.txt
+```
+
+---
+
+## Running Tests
+### Backend Tests (pytest)
+```
+npm run test:backend
+```
+
+### Frontend Tests (Jest & RTL)
+```
+npm run test:frontend
+```
+
+### Full Suite (backend + frontend)
+```
+npm test
 ```
 
 --- 
@@ -121,62 +149,27 @@ pip install -r requirements-dev.txt
 
 ---
 
-## Running Tests
-### Backend Tests
-Run directly:
-
-```
-cd backend
-pytest -v
-```
-
-Or via npm script:
-```
-npm run test:backend
-```
-This runs both model tests and API route tests (CRUD for Events) against an in-memory SQLite database.
-
-### Frontend Tests
-Run directly:
-
-```
-cd frontend
-npm test
-```
-
-Or via npm script:
-```
-npm run test:frontend
-```
-
-### Full Suite (backend + frontend)
-```
-npm test
-```
-
---- 
-
 ## Project Structure
 ```
+## Project Structure
+
 hero-tournament-manager/
-├── backend/
+├── backend/                # Flask backend (API + models + routes + tests)
 │   ├── app.py
 │   ├── config.py
 │   ├── models.py
+│   ├── requirements.txt
 │   ├── routes/
-│   │   ├── __init__.py
 │   │   ├── events.py
 │   │   ├── entrants.py
 │   │   └── matches.py
-│   ├── tests/
-│   │   ├── conftest.py
-│   │   ├── test_models.py
-│   │   ├── test_routes_events.py
-│   │   ├── test_routes_entrants.py
-│   │   └── test_routes_matches.py
-│   └── requirements.txt
+│   └── tests/
+│       ├── test_models.py
+│       ├── test_routes_events.py
+│       ├── test_routes_entrants.py
+│       └── test_routes_matches.py
 │
-├── frontend/
+├── frontend/               # React frontend
 │   ├── package.json
 │   ├── public/
 │   └── src/
@@ -190,11 +183,13 @@ hero-tournament-manager/
 │           ├── App.test.jsx
 │           └── EventDashboard.test.jsx
 │
-├── venv/
-├── requirements-dev.txt
-├── package.json        # root-level, manages lint/test scripts
-├── README.md
-└── LICENSE
+├── venv/                   # Python virtual environment (ignored in Git)
+├── requirements-dev.txt    # Dev-only Python deps (pytest, flake8, black)
+├── package.json            # Root-level scripts (lint/test orchestration)
+├── pyproject.toml          # Config for tools like Black
+├── pytest.ini              # Pytest config
+├── README.md               # Project docs
+└── LICENSE                 # License file
 ```
 
 ## Future Improvements

--- a/backend/app.py
+++ b/backend/app.py
@@ -11,6 +11,7 @@ from backend.routes.entrants import bp as entrants_bp
 from backend.routes.matches import bp as matches_bp
 from flask_cors import CORS
 
+
 def create_app():
     app = Flask(__name__)
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///tournaments.db"

--- a/backend/routes/events.py
+++ b/backend/routes/events.py
@@ -31,12 +31,21 @@ def create_event():
 def get_events():
     """Retrieve all Events."""
     events = Event.query.all()
-    return jsonify(
-        [
-            {"id": e.id, "name": e.name, "date": e.date, "rules": e.rules, "status": e.status}
-            for e in events
-        ]
-    ), 200
+    return (
+        jsonify(
+            [
+                {
+                    "id": e.id,
+                    "name": e.name,
+                    "date": e.date,
+                    "rules": e.rules,
+                    "status": e.status,
+                }
+                for e in events
+            ]
+        ),
+        200,
+    )
 
 
 @bp.route("/<int:event_id>", methods=["PUT"])
@@ -47,9 +56,18 @@ def update_event(event_id):
     for key, value in data.items():
         setattr(event, key, value)
     db.session.commit()
-    return jsonify(
-        {"id": event.id, "name": event.name, "date": event.date, "rules": event.rules, "status": event.status}
-    ), 200
+    return (
+        jsonify(
+            {
+                "id": event.id,
+                "name": event.name,
+                "date": event.date,
+                "rules": event.rules,
+                "status": event.status,
+            }
+        ),
+        200,
+    )
 
 
 @bp.route("/<int:event_id>", methods=["DELETE"])

--- a/backend/tests/test_routes_entrants.py
+++ b/backend/tests/test_routes_entrants.py
@@ -6,7 +6,6 @@
 # - Covers create, read, update, delete operations for Entrants.
 # - Runs against an in-memory SQLite database for isolation.
 
-import pytest
 from backend.models import Event, Entrant, db
 from sqlalchemy import select
 
@@ -55,7 +54,7 @@ def test_update_entrant(client):
     assert response.status_code == 200
     data = response.get_json()
     assert data["alias"] == "Updated Alias"
-    
+
     result = db.session.execute(select(Entrant).filter_by(id=entrant.id)).scalar_one()
     assert result.alias == "Updated Alias"
 
@@ -69,5 +68,7 @@ def test_delete_entrant(client):
     response = client.delete(f"/entrants/{entrant.id}")
 
     assert response.status_code == 204
-    result = db.session.execute(select(Entrant).filter_by(id=entrant.id)).scalar_one_or_none()
+    result = db.session.execute(
+        select(Entrant).filter_by(id=entrant.id)
+    ).scalar_one_or_none()
     assert result is None

--- a/backend/tests/test_routes_events.py
+++ b/backend/tests/test_routes_events.py
@@ -5,7 +5,6 @@
 # - Covers create, read, update, delete operations for Event.
 # - Runs against an in-memory SQLite database for isolation.
 
-import pytest
 from backend.models import Event, db
 from sqlalchemy import select
 
@@ -13,7 +12,12 @@ from sqlalchemy import select
 def test_create_event(client):
     response = client.post(
         "/events",
-        json={"name": "Hero Cup", "date": "2025-09-12", "rules": "Bo3", "status": "open"},
+        json={
+            "name": "Hero Cup",
+            "date": "2025-09-12",
+            "rules": "Bo3",
+            "status": "open",
+        },
     )
     assert response.status_code == 201
     data = response.get_json()
@@ -65,5 +69,7 @@ def test_delete_event(client):
 
     # Assert
     assert response.status_code == 204
-    result = db.session.execute(select(Event).filter_by(id=event.id)).scalar_one_or_none()
+    result = db.session.execute(
+        select(Event).filter_by(id=event.id)
+    ).scalar_one_or_none()
     assert result is None

--- a/backend/tests/test_routes_matches.py
+++ b/backend/tests/test_routes_matches.py
@@ -6,7 +6,6 @@
 # - Covers create, read, update, delete operations for Matches.
 # - Runs against an in-memory SQLite database for isolation.
 
-import pytest
 from backend.models import Event, Entrant, Match, db
 from sqlalchemy import select
 
@@ -102,5 +101,7 @@ def test_delete_match(client):
     response = client.delete(f"/matches/{match.id}")
 
     assert response.status_code == 204
-    result = db.session.execute(select(Match).filter_by(id=match.id)).scalar_one_or_none()
+    result = db.session.execute(
+        select(Match).filter_by(id=match.id)
+    ).scalar_one_or_none()
     assert result is None

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,3 @@
+build
+node_modules
+coverage

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint src --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
+    "format": "prettier --write src"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,9 +4,9 @@
 // - Sets up routing for dashboard and event detail.
 // - Provides navigation link placeholders for now.
 
-import { Routes, Route } from "react-router-dom"
-import EventDashboard from "./components/EventDashboard"
-import EventDetail from "./components/EventDetail"
+import { Routes, Route } from "react-router-dom";
+import EventDashboard from "./components/EventDashboard";
+import EventDetail from "./components/EventDetail";
 
 function App() {
   return (
@@ -17,7 +17,7 @@ function App() {
         <Route path="/events/:id" element={<EventDetail />} />
       </Routes>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -3,27 +3,27 @@
 // Notes:
 // - Uses renderWithRouter to simplify MemoryRouter wrapping.
 
-import { screen } from "@testing-library/react"
-import App from "../App"
-import { renderWithRouter } from "../test-utils"
+import { screen } from "@testing-library/react";
+import App from "../App";
+import { renderWithRouter } from "../test-utils";
 
 describe("App routing", () => {
   test("renders Hero Tournament Manager heading on home route", () => {
-    renderWithRouter(<App />, { route: "/" })
-    expect(screen.getByText(/Hero Tournament Manager/i)).toBeInTheDocument()
-  })
+    renderWithRouter(<App />, { route: "/" });
+    expect(screen.getByText(/Hero Tournament Manager/i)).toBeInTheDocument();
+  });
 
   test("renders EventDashboard on home route", () => {
-    renderWithRouter(<App />, { route: "/" })
-    expect(screen.getByText(/events/i)).toBeInTheDocument()
-  })
+    renderWithRouter(<App />, { route: "/" });
+    expect(screen.getByText(/events/i)).toBeInTheDocument();
+  });
 
   test("renders EventDetail on event detail route", async () => {
-    renderWithRouter(<App />, { route: "/events/1" })
-    expect(await screen.findByText(/Event Detail/i)).toBeInTheDocument()
-  })
+    renderWithRouter(<App />, { route: "/events/1" });
+    expect(await screen.findByText(/Event Detail/i)).toBeInTheDocument();
+  });
 
   test.skip("navigates between Dashboard and EventDetail", () => {
     // Will implement once EventDashboard has <Link>
-  })
-})
+  });
+});

--- a/frontend/src/__tests__/EventDashboard.test.jsx
+++ b/frontend/src/__tests__/EventDashboard.test.jsx
@@ -3,31 +3,31 @@
 // Notes:
 // - Uses renderWithRouter for consistent Router context.
 
-import { screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import EventDashboard from "../components/EventDashboard"
-import { renderWithRouter } from "../test-utils"
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EventDashboard from "../components/EventDashboard";
+import { renderWithRouter } from "../test-utils";
 
 test("renders Events heading", () => {
-  renderWithRouter(<EventDashboard />)
-  expect(screen.getByText(/events/i)).toBeInTheDocument()
-})
+  renderWithRouter(<EventDashboard />);
+  expect(screen.getByText(/events/i)).toBeInTheDocument();
+});
 
 test("displays events returned from API", async () => {
-  renderWithRouter(<EventDashboard />)
-  expect(await screen.findByText(/Hero Cup/)).toBeInTheDocument()
-  expect(await screen.findByText(/Villain Showdown/)).toBeInTheDocument()
-})
+  renderWithRouter(<EventDashboard />);
+  expect(await screen.findByText(/Hero Cup/)).toBeInTheDocument();
+  expect(await screen.findByText(/Villain Showdown/)).toBeInTheDocument();
+});
 
 test("shows empty state when no events exist", async () => {
   global.fetch.mockResolvedValueOnce({
     ok: true,
     json: async () => [],
-  })
+  });
 
-  renderWithRouter(<EventDashboard />)
-  expect(await screen.findByText(/no events available/i)).toBeInTheDocument()
-})
+  renderWithRouter(<EventDashboard />);
+  expect(await screen.findByText(/no events available/i)).toBeInTheDocument();
+});
 
 test("adds new event after form submission", async () => {
   // Override fetch sequence: GET empty → POST → GET with new event
@@ -52,14 +52,14 @@ test("adds new event after form submission", async () => {
           status: "closed",
         },
       ],
-    })
+    });
 
-  renderWithRouter(<EventDashboard />)
+  renderWithRouter(<EventDashboard />);
 
-  await userEvent.type(screen.getByLabelText(/name/i), "Villain Showdown")
-  await userEvent.type(screen.getByLabelText(/date/i), "2025-09-13")
-  await userEvent.selectOptions(screen.getByLabelText(/status/i), "closed")
-  await userEvent.click(screen.getByRole("button", { name: /create event/i }))
+  await userEvent.type(screen.getByLabelText(/name/i), "Villain Showdown");
+  await userEvent.type(screen.getByLabelText(/date/i), "2025-09-13");
+  await userEvent.selectOptions(screen.getByLabelText(/status/i), "closed");
+  await userEvent.click(screen.getByRole("button", { name: /create event/i }));
 
-  expect(await screen.findByText(/Villain Showdown/)).toBeInTheDocument()
-})
+  expect(await screen.findByText(/Villain Showdown/)).toBeInTheDocument();
+});

--- a/frontend/src/__tests__/EventDetail.test.jsx
+++ b/frontend/src/__tests__/EventDetail.test.jsx
@@ -4,9 +4,9 @@
 // - Uses renderWithRouter so component has Router context.
 // - Mocks fetch responses to simulate backend API.
 
-import { screen } from "@testing-library/react"
-import EventDetail from "../components/EventDetail"
-import { renderWithRouter } from "../test-utils"
+import { screen } from "@testing-library/react";
+import EventDetail from "../components/EventDetail";
+import { renderWithRouter } from "../test-utils";
 
 describe("EventDetail", () => {
   test("renders event name and date", async () => {
@@ -21,13 +21,13 @@ describe("EventDetail", () => {
         entrants: [],
         matches: [],
       }),
-    })
+    });
 
-    renderWithRouter(<EventDetail eventId={1} />, { route: "/events/1" })
+    renderWithRouter(<EventDetail eventId={1} />, { route: "/events/1" });
 
-    expect(await screen.findByText(/Hero Cup/)).toBeInTheDocument()
-    expect(await screen.findByText(/2025-09-12/)).toBeInTheDocument()
-  })
+    expect(await screen.findByText(/Hero Cup/)).toBeInTheDocument();
+    expect(await screen.findByText(/2025-09-12/)).toBeInTheDocument();
+  });
 
   test("renders entrants list", async () => {
     global.fetch.mockResolvedValueOnce({
@@ -44,13 +44,13 @@ describe("EventDetail", () => {
         ],
         matches: [],
       }),
-    })
+    });
 
-    renderWithRouter(<EventDetail eventId={1} />, { route: "/events/1" })
+    renderWithRouter(<EventDetail eventId={1} />, { route: "/events/1" });
 
-    expect(await screen.findByText(/Spiderman/)).toBeInTheDocument()
-    expect(await screen.findByText(/Batman/)).toBeInTheDocument()
-  })
+    expect(await screen.findByText(/Spiderman/)).toBeInTheDocument();
+    expect(await screen.findByText(/Batman/)).toBeInTheDocument();
+  });
 
   test("renders matches list", async () => {
     global.fetch.mockResolvedValueOnce({
@@ -62,15 +62,13 @@ describe("EventDetail", () => {
         rules: "Bo3",
         status: "open",
         entrants: [],
-        matches: [
-          { id: 1, round: 1, scores: "2-1", winner: "Spiderman" },
-        ],
+        matches: [{ id: 1, round: 1, scores: "2-1", winner: "Spiderman" }],
       }),
-    })
+    });
 
-    renderWithRouter(<EventDetail eventId={1} />, { route: "/events/1" })
+    renderWithRouter(<EventDetail eventId={1} />, { route: "/events/1" });
 
-    expect(await screen.findByText(/Round 1/)).toBeInTheDocument()
-    expect(await screen.findByText(/Winner: Spiderman/)).toBeInTheDocument()
-  })
-})
+    expect(await screen.findByText(/Round 1/)).toBeInTheDocument();
+    expect(await screen.findByText(/Winner: Spiderman/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/EventDashboard.jsx
+++ b/frontend/src/components/EventDashboard.jsx
@@ -5,47 +5,51 @@
 // - Provides form to create new events.
 // - Re-fetches event list after creating an event.
 
-import { useState, useEffect } from "react"
-import { Link } from "react-router-dom"
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 
 function EventDashboard() {
-  const [events, setEvents] = useState([])
-  const [loading, setLoading] = useState(true)
-  const [formData, setFormData] = useState({ name: "", date: "", status: "open" })
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [formData, setFormData] = useState({
+    name: "",
+    date: "",
+    status: "open",
+  });
 
   async function fetchEvents() {
     try {
-      const response = await fetch("http://localhost:5500/events")
-      if (!response.ok) throw new Error("Failed to fetch events")
-      const data = await response.json()
-      setEvents(data)
+      const response = await fetch("http://localhost:5500/events");
+      if (!response.ok) throw new Error("Failed to fetch events");
+      const data = await response.json();
+      setEvents(data);
     } catch (err) {
-      console.error(err)
-      setEvents([])
+      console.error(err);
+      setEvents([]);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
   }
 
   useEffect(() => {
-    fetchEvents()
-  }, [])
+    fetchEvents();
+  }, []);
 
   async function handleSubmit(e) {
-    e.preventDefault()
+    e.preventDefault();
     try {
       const response = await fetch("http://localhost:5500/events", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(formData),
-      })
-      if (!response.ok) throw new Error("Failed to create event")
+      });
+      if (!response.ok) throw new Error("Failed to create event");
       // Re-fetch events after creation
-      await fetchEvents()
+      await fetchEvents();
       // Reset form
-      setFormData({ name: "", date: "", status: "open" })
+      setFormData({ name: "", date: "", status: "open" });
     } catch (err) {
-      console.error(err)
+      console.error(err);
     }
   }
 
@@ -79,7 +83,9 @@ function EventDashboard() {
           <select
             id="status"
             value={formData.status}
-            onChange={(e) => setFormData({ ...formData, status: e.target.value })}
+            onChange={(e) =>
+              setFormData({ ...formData, status: e.target.value })
+            }
           >
             <option value="open">Open</option>
             <option value="closed">Closed</option>
@@ -105,7 +111,7 @@ function EventDashboard() {
         <p>No events available</p>
       )}
     </div>
-  )
+  );
 }
 
-export default EventDashboard
+export default EventDashboard;

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -5,32 +5,32 @@
 // - Renders event info, entrants list, and matches list.
 // - Handles loading and error states gracefully.
 
-import { useEffect, useState } from "react"
+import { useEffect, useState } from "react";
 
 export default function EventDetail({ eventId }) {
-  const [event, setEvent] = useState(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(null)
+  const [event, setEvent] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     async function fetchEvent() {
       try {
-        const response = await fetch(`/events/${eventId}`)
-        if (!response.ok) throw new Error("Failed to fetch event")
-        const data = await response.json()
-        setEvent(data)
+        const response = await fetch(`/events/${eventId}`);
+        if (!response.ok) throw new Error("Failed to fetch event");
+        const data = await response.json();
+        setEvent(data);
       } catch (err) {
-        setError(err.message)
+        setError(err.message);
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     }
-    fetchEvent()
-  }, [eventId])
+    fetchEvent();
+  }, [eventId]);
 
-  if (loading) return <p>Loading event...</p>
-  if (error) return <p>Error: {error}</p>
-  if (!event) return <p>No event found</p>
+  if (loading) return <p>Loading event...</p>;
+  if (error) return <p>Error: {error}</p>;
+  if (!event) return <p>No event found</p>;
 
   return (
     <div>
@@ -63,5 +63,5 @@ export default function EventDetail({ eventId }) {
         <p>No matches yet</p>
       )}
     </div>
-  )
+  );
 }

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,18 +3,18 @@
 // Notes:
 // - Mounts the App component into the root DOM node.
 
-import React from "react"
-import { createRoot } from "react-dom/client"
-import { BrowserRouter } from "react-router-dom"
-import App from "./App"
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
 
-const container = document.getElementById("root")
-const root = createRoot(container)
+const container = document.getElementById("root");
+const root = createRoot(container);
 
 root.render(
   <React.StrictMode>
     <BrowserRouter>
       <App />
     </BrowserRouter>
-  </React.StrictMode>
-)
+  </React.StrictMode>,
+);

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -5,7 +5,7 @@
 // - Provides a default global.fetch mock that can be overridden per test.
 // - Suppresses common React warnings by ensuring state updates happen inside act.
 
-import "@testing-library/jest-dom"
+import "@testing-library/jest-dom";
 
 // Default fetch mock
 beforeEach(() => {
@@ -15,26 +15,31 @@ beforeEach(() => {
       json: () =>
         Promise.resolve([
           { id: 1, name: "Hero Cup", date: "2025-09-12", status: "open" },
-          { id: 2, name: "Villain Showdown", date: "2025-09-13", status: "closed" }
-        ])
-    })
-  )
-})
+          {
+            id: 2,
+            name: "Villain Showdown",
+            date: "2025-09-13",
+            status: "closed",
+          },
+        ]),
+    }),
+  );
+});
 
 // Reset mocks between tests
 afterEach(() => {
-  jest.clearAllMocks()
-})
+  jest.clearAllMocks();
+});
 
 // Silence act(...) warnings in tests (since we handle async with findBy/waitFor)
-const originalError = console.error
+const originalError = console.error;
 beforeAll(() => {
   console.error = (...args) => {
-    if (/not wrapped in act/.test(args[0])) return
-    originalError.call(console, ...args)
-  }
-})
+    if (/not wrapped in act/.test(args[0])) return;
+    originalError.call(console, ...args);
+  };
+});
 
 afterAll(() => {
-  console.error = originalError
-})
+  console.error = originalError;
+});

--- a/frontend/src/test-utils.js
+++ b/frontend/src/test-utils.js
@@ -3,9 +3,9 @@
 // - Wraps components in MemoryRouter so <Link>/<Route> always have context.
 // - Extend this later with more providers (Redux, Context, etc).
 
-import { render } from "@testing-library/react"
-import { MemoryRouter } from "react-router-dom"
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 
 export function renderWithRouter(ui, { route = "/" } = {}) {
-  return render(<MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>)
+  return render(<MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>);
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 
     
     "lint:frontend": "cd frontend && npm run lint",
-    "format:frontend": "cd frontend && npx prettier --write .",
+    "format:frontend": "cd frontend && npm run format",
+    "fix:frontend": "cd frontend && npm run format && npm run lint",
     "test:frontend": "cd frontend && npm test",
     "start:frontend": "cd frontend && npm start",
 

--- a/package.json
+++ b/package.json
@@ -3,13 +3,19 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    
     "lint:backend": "flake8 backend",
     "format:backend": "black backend",
     "fix:backend": "black backend && flake8 backend",
-    "lint:frontend": "cd frontend && npm run lint",
     "test:backend": "pytest -q --disable-warnings",
+
+    
+    "lint:frontend": "cd frontend && npm run lint",
+    "format:frontend": "cd frontend && npx prettier --write .",
     "test:frontend": "cd frontend && npm test",
     "start:frontend": "cd frontend && npm start",
+
+    
     "test": "npm run test:backend && npm run test:frontend"
   },
   "devDependencies": {}


### PR DESCRIPTION
## Summary
This PR introduces development tooling polish across backend and frontend, along with documentation updates for contributors.

## Changes
- **Backend**
  - Added `flake8` linting, `black` formatting, and a combined `fix:backend` script in root `package.json`
  - Cleaned up unused `pytest` imports flagged by linter
- **Frontend**
  - Added `eslint` and `prettier` integration
  - Added scripts for `lint:frontend`, `format:frontend`, and `fix:frontend` in both frontend and root `package.json`
  - Created `.prettierignore` to exclude build artifacts from formatting
- **Docs**
  - Updated **README** with sections for linting, formatting, and one-step fix commands for backend and frontend
  - Added project structure tree with comments for clarity

## Next Steps
- CI integration for lint/format/test scripts
- Potential pre-commit hooks for auto-formatting