### PR TITLE
Fix match winner handling in EventDetail and MatchDashboard

### DIFF
--- a/frontend/src/__tests__/EventDetail.test.jsx
+++ b/frontend/src/__tests__/EventDetail.test.jsx
@@ -97,4 +97,28 @@ describe("EventDetail", () => {
     expect(await screen.findByText(/Ironman/)).toBeInTheDocument();
     expect(await screen.findByText(/Tony/)).toBeInTheDocument();
   });
+
+  test("renders match winner by entrant name", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 1,
+        name: "Hero Cup",
+        date: "2025-09-12",
+        status: "open",
+        entrants: [
+          { id: 1, name: "Spiderman", alias: "Webslinger" },
+          { id: 2, name: "Batman", alias: "Dark Knight" },
+        ],
+        matches: [
+          { id: 10, round: 1, scores: "2-1", winner_id: 2 },
+        ],
+      }),
+    });
+
+    renderWithRouter(<EventDetail eventId={1} />, { route: "/events/1" });
+
+    expect(await screen.findByText(/Round 1: 2-1/)).toBeInTheDocument();
+    expect(await screen.findByText(/Winner: Batman \(Dark Knight\)/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/__tests__/EventDetail.test.jsx
+++ b/frontend/src/__tests__/EventDetail.test.jsx
@@ -93,7 +93,7 @@ describe("EventDetail", () => {
     await userEvent.type(screen.getByLabelText(/alias/i), "Tony");
     await userEvent.click(screen.getByRole("button", { name: /add entrant/i }));
 
-    // ✅ Check entrants in EventDetail’s list
+    // Check entrants in EventDetail’s list
     expect(await screen.findByText(/Ironman/)).toBeInTheDocument();
     expect(await screen.findByText(/Tony/)).toBeInTheDocument();
   });

--- a/frontend/src/__tests__/MatchDashboard.test.jsx
+++ b/frontend/src/__tests__/MatchDashboard.test.jsx
@@ -1,8 +1,7 @@
 // File: frontend/src/__tests__/MatchDashboard.test.jsx
 // Purpose: Tests for MatchDashboard component.
 // Notes:
-// - Only tests form submission since EventDetail owns match list.
-// - Ensures callback is called after POST.
+// - Ensures POST includes winner_id and callback is called.
 
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -17,10 +16,10 @@ describe("MatchDashboard", () => {
     expect(screen.getByLabelText(/entrant 1 id/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/entrant 2 id/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/scores/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/winner/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/winner id/i)).toBeInTheDocument();
   });
 
-  test("submits new match and triggers callback", async () => {
+  test("submits new match with winner_id and triggers callback", async () => {
     const mockOnAdded = jest.fn();
 
     global.fetch.mockResolvedValueOnce({
@@ -31,7 +30,7 @@ describe("MatchDashboard", () => {
         entrant1_id: 1,
         entrant2_id: 2,
         scores: "2-0",
-        winner: "Spiderman",
+        winner_id: 1,
         event_id: 1,
       }),
     });
@@ -42,7 +41,7 @@ describe("MatchDashboard", () => {
     await userEvent.type(screen.getByLabelText(/entrant 1 id/i), "1");
     await userEvent.type(screen.getByLabelText(/entrant 2 id/i), "2");
     await userEvent.type(screen.getByLabelText(/scores/i), "2-0");
-    await userEvent.type(screen.getByLabelText(/winner/i), "Spiderman");
+    await userEvent.type(screen.getByLabelText(/winner id/i), "1");
 
     await userEvent.click(screen.getByRole("button", { name: /add match/i }));
 

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -1,8 +1,6 @@
 // File: frontend/src/components/EventDetail.jsx
 // Purpose: Displays details for a single Event, including entrants and matches.
 // Notes:
-// - Uses REACT_APP_API_URL env var for backend requests.
-// - Integrates EntrantDashboard + MatchDashboard for CRUD operations.
 // - Resolves winner_id to entrant name/alias, falls back to TBD.
 
 import { useEffect, useState } from "react";
@@ -69,7 +67,9 @@ export default function EventDetail() {
       {event.matches?.length > 0 ? (
         <ul>
           {event.matches.map((m) => {
-            const winner = event.entrants?.find((e) => e.id === m.winner_id);
+            const winner = event.entrants?.find(
+              (e) => String(e.id) === String(m.winner_id)
+            );
             return (
               <li key={m.id}>
                 Round {m.round}: {m.scores} — Winner:{" "}

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -3,6 +3,7 @@
 // Notes:
 // - Uses REACT_APP_API_URL env var for backend requests.
 // - Integrates EntrantDashboard + MatchDashboard for CRUD operations.
+// - Resolves winner_id to entrant name/alias, falls back to TBD.
 
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
@@ -67,11 +68,15 @@ export default function EventDetail() {
       <MatchDashboard eventId={id} onMatchAdded={fetchEvent} />
       {event.matches?.length > 0 ? (
         <ul>
-          {event.matches.map((m) => (
-            <li key={m.id}>
-              Round {m.round}: {m.scores} — Winner: {m.winner || "TBD"}
-            </li>
-          ))}
+          {event.matches.map((m) => {
+            const winner = event.entrants?.find((e) => e.id === m.winner_id);
+            return (
+              <li key={m.id}>
+                Round {m.round}: {m.scores} — Winner:{" "}
+                {winner ? `${winner.name} (${winner.alias})` : "TBD"}
+              </li>
+            );
+          })}
         </ul>
       ) : (
         <p>No matches yet</p>

--- a/frontend/src/components/MatchDashboard.jsx
+++ b/frontend/src/components/MatchDashboard.jsx
@@ -1,8 +1,9 @@
 // File: frontend/src/components/MatchDashboard.jsx
 // Purpose: Form for managing matches for an event.
 // Notes:
-// - Does NOT render list; parent (EventDetail) owns matches.
+// - Posts winner_id (not winner string).
 // - Calls onMatchAdded after POST.
+// - Resets form after submit.
 
 import { useState } from "react";
 import { API_BASE_URL } from "../api";
@@ -13,25 +14,37 @@ export default function MatchDashboard({ eventId, onMatchAdded }) {
     entrant1_id: "",
     entrant2_id: "",
     scores: "",
-    winner: "",
+    winner_id: "",
   });
 
   async function handleSubmit(e) {
     e.preventDefault();
     try {
+      const payload = {
+        round: parseInt(formData.round, 10),
+        entrant1_id: parseInt(formData.entrant1_id, 10),
+        entrant2_id: parseInt(formData.entrant2_id, 10),
+        scores: formData.scores,
+        winner_id: parseInt(formData.winner_id, 10),
+        event_id: parseInt(eventId, 10),
+      };
+
       const response = await fetch(`${API_BASE_URL}/matches`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...formData, event_id: eventId }),
+        body: JSON.stringify(payload),
       });
+
       if (!response.ok) throw new Error("Failed to add match");
+
       setFormData({
         round: "",
         entrant1_id: "",
         entrant2_id: "",
         scores: "",
-        winner: "",
+        winner_id: "",
       });
+
       if (typeof onMatchAdded === "function") onMatchAdded();
     } catch (err) {
       console.error(err);
@@ -81,12 +94,12 @@ export default function MatchDashboard({ eventId, onMatchAdded }) {
           />
         </div>
         <div>
-          <label htmlFor="winner">Winner</label>
+          <label htmlFor="winner_id">Winner ID</label>
           <input
-            id="winner"
-            value={formData.winner}
+            id="winner_id"
+            value={formData.winner_id}
             onChange={(e) =>
-              setFormData({ ...formData, winner: e.target.value })
+              setFormData({ ...formData, winner_id: e.target.value })
             }
           />
         </div>


### PR DESCRIPTION
## Summary
Fixes match winner handling in EventDetail. Matches now store `winner_id` and display the correct entrant name + alias instead of defaulting to "TBD".

## Changes
- Updated `MatchDashboard` to submit `winner_id` instead of raw string
- Updated `EventDetail` to resolve `winner_id` against entrants for display
- Added tests in `EventDetail.test.jsx` for winner rendering
- Added tests in `MatchDashboard.test.jsx` for match submission with winner

## Testing
- Ran `npm test` --> all frontend tests pass, including new winner-related tests
- Verified manually in browser:
  - Entrants can be created
  - Matches can be created with winner ID
  - EventDetail correctly shows winner’s name + alias