### PR TITLE
feat(backend): add SQLAlchemy models, routes, and seed scripts

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -4,6 +4,9 @@
 # - Event: Tournament event (name, date, rules, status)
 # - Entrant: Player/character registered in an event
 # - Match: A match within an event, with entrants, round, scores, winner
+# Notes:
+# - Includes to_dict() methods with optional related info.
+# - Match.to_dict(include_names=True) returns entrant + winner details.
 
 from flask_sqlalchemy import SQLAlchemy
 
@@ -84,8 +87,8 @@ class Match(db.Model):
     def __repr__(self):
         return f"<Match Event {self.event_id} Round {self.round}>"
 
-    def to_dict(self):
-        return {
+    def to_dict(self, include_names=False):
+        data = {
             "id": self.id,
             "event_id": self.event_id,
             "round": self.round,
@@ -94,3 +97,24 @@ class Match(db.Model):
             "scores": self.scores,
             "winner_id": self.winner_id,
         }
+
+        if include_names:
+            from backend.models import Entrant  # local import to avoid circular
+
+            data["entrant1"] = (
+                Entrant.query.get(self.entrant1_id).to_dict()
+                if self.entrant1_id
+                else None
+            )
+            data["entrant2"] = (
+                Entrant.query.get(self.entrant2_id).to_dict()
+                if self.entrant2_id
+                else None
+            )
+            data["winner"] = (
+                Entrant.query.get(self.winner_id).to_dict()
+                if self.winner_id
+                else None
+            )
+
+        return data

--- a/backend/routes/events.py
+++ b/backend/routes/events.py
@@ -3,6 +3,7 @@
 # Notes:
 # - Supports create, read (list), update, and delete.
 # - Uses Event.to_dict() for consistent serialization.
+# - Enriches matches with entrant names when returning a single event.
 
 from flask import Blueprint, request, jsonify
 from backend.models import db, Event
@@ -34,9 +35,12 @@ def get_events():
 
 @bp.route("/<int:event_id>", methods=["GET"])
 def get_event(event_id):
-    """Retrieve a single Event with entrants + matches."""
+    """Retrieve a single Event with entrants + matches (with names)."""
     event = Event.query.get_or_404(event_id)
-    return jsonify(event.to_dict(include_related=True)), 200
+    data = event.to_dict(include_related=True)
+    # enrich matches with entrant names
+    data["matches"] = [m.to_dict(include_names=True) for m in event.matches]
+    return jsonify(data), 200
 
 
 @bp.route("/<int:event_id>", methods=["PUT"])

--- a/backend/routes/matches.py
+++ b/backend/routes/matches.py
@@ -3,6 +3,7 @@
 # Notes:
 # - Supports create, read (list), update, and delete.
 # - Uses Match.to_dict() for consistent serialization.
+# - Always returns matches with entrant names for frontend convenience.
 
 from flask import Blueprint, request, jsonify
 from backend.models import db, Match
@@ -24,7 +25,7 @@ def create_match():
     )
     db.session.add(match)
     db.session.commit()
-    return jsonify(match.to_dict()), 201
+    return jsonify(match.to_dict(include_names=True)), 201
 
 
 @bp.route("", methods=["GET"])
@@ -35,7 +36,7 @@ def get_matches():
     if event_id:
         query = query.filter_by(event_id=event_id)
     matches = query.all()
-    return jsonify([m.to_dict() for m in matches]), 200
+    return jsonify([m.to_dict(include_names=True) for m in matches]), 200
 
 
 @bp.route("/<int:match_id>", methods=["PUT"])
@@ -46,7 +47,7 @@ def update_match(match_id):
     for key, value in data.items():
         setattr(match, key, value)
     db.session.commit()
-    return jsonify(match.to_dict()), 200
+    return jsonify(match.to_dict(include_names=True)), 200
 
 
 @bp.route("/<int:match_id>", methods=["DELETE"])

--- a/backend/scripts/clear_db.py
+++ b/backend/scripts/clear_db.py
@@ -1,0 +1,11 @@
+# File: backend/scripts/clear_db.py
+# Purpose: Drop and recreate all tables.
+
+from backend.app import create_app
+from backend.models import db
+
+app = create_app()
+with app.app_context():
+    db.drop_all()
+    db.create_all()
+    print("💥 All tables dropped & recreated fresh.")

--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -1,0 +1,33 @@
+// File: backend/scripts/seed.js
+// Purpose: Load seed JSON data into memory (or forward to Flask API later).
+// Notes:
+// - Uses Node fs + path to load JSON files.
+// - Currently just logs counts. Replace TODO section to POST to Flask API
+//   or integrate directly with DB if you set up a JS ORM later.
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Helper to load a seed file from backend/seeds/
+function loadSeed(file) {
+  const data = fs.readFileSync(
+    path.join(__dirname, "..", "seeds", file),
+    "utf-8"
+  );
+  return JSON.parse(data);
+}
+
+// Load seed data
+const events = loadSeed("events.json");
+const entrants = loadSeed("entrants.json");
+const matches = loadSeed("matches.json");
+
+// Log summary
+console.log("🌱 Seeding data...");
+console.log("Events:", events.length);
+console.log("Entrants:", entrants.length);
+console.log("Matches:", matches.length);

--- a/backend/scripts/seed_db.py
+++ b/backend/scripts/seed_db.py
@@ -1,0 +1,52 @@
+# File: backend/scripts/seed_db.py
+# Purpose: Load JSON seed data into the Flask DB.
+# Notes:
+# - Reads from backend/seeds/events.json, entrants.json, matches.json
+# - Inserts into SQLAlchemy models via Flask app context.
+# - Run with: npm run db:clear && npm run db:seed
+
+import os
+import json
+from backend.app import create_app
+from backend.models import db, Event, Entrant, Match
+
+SEED_DIR = os.path.join(os.path.dirname(__file__), "..", "seeds")
+
+def load_seed(filename):
+    with open(os.path.join(SEED_DIR, filename), "r") as f:
+        return json.load(f)
+
+def run():
+    app = create_app()
+    with app.app_context():
+        print("🌱 Seeding database...")
+
+        events = load_seed("events.json")
+        entrants = load_seed("entrants.json")
+        matches = load_seed("matches.json")
+
+        # Insert Events
+        for e in events:
+            db.session.add(Event(id=e["id"], name=e["name"], date=e["date"], status=e["status"]))
+
+        # Insert Entrants
+        for en in entrants:
+            db.session.add(Entrant(id=en["id"], name=en["name"], alias=en["alias"], event_id=en["event_id"]))
+
+        # Insert Matches
+        for m in matches:
+            db.session.add(Match(
+                id=m["id"],
+                round=m["round"],
+                entrant1_id=m["entrant1_id"],
+                entrant2_id=m["entrant2_id"],
+                scores=m["scores"],
+                winner_id=m["winner_id"],
+                event_id=m["event_id"]
+            ))
+
+        db.session.commit()
+        print(f"✅ Inserted {len(events)} events, {len(entrants)} entrants, {len(matches)} matches")
+
+if __name__ == "__main__":
+    run()

--- a/backend/seeds/entrants.json
+++ b/backend/seeds/entrants.json
@@ -1,0 +1,302 @@
+[
+  {
+    "id": 1,
+    "name": "Hero 1",
+    "alias": "Alias1",
+    "event_id": 1
+  },
+  {
+    "id": 2,
+    "name": "Hero 2",
+    "alias": "Alias2",
+    "event_id": 2
+  },
+  {
+    "id": 3,
+    "name": "Hero 3",
+    "alias": "Alias3",
+    "event_id": 3
+  },
+  {
+    "id": 4,
+    "name": "Hero 4",
+    "alias": "Alias4",
+    "event_id": 4
+  },
+  {
+    "id": 5,
+    "name": "Hero 5",
+    "alias": "Alias5",
+    "event_id": 5
+  },
+  {
+    "id": 6,
+    "name": "Hero 6",
+    "alias": "Alias6",
+    "event_id": 1
+  },
+  {
+    "id": 7,
+    "name": "Hero 7",
+    "alias": "Alias7",
+    "event_id": 2
+  },
+  {
+    "id": 8,
+    "name": "Hero 8",
+    "alias": "Alias8",
+    "event_id": 3
+  },
+  {
+    "id": 9,
+    "name": "Hero 9",
+    "alias": "Alias9",
+    "event_id": 4
+  },
+  {
+    "id": 10,
+    "name": "Hero 10",
+    "alias": "Alias10",
+    "event_id": 5
+  },
+  {
+    "id": 11,
+    "name": "Hero 11",
+    "alias": "Alias11",
+    "event_id": 1
+  },
+  {
+    "id": 12,
+    "name": "Hero 12",
+    "alias": "Alias12",
+    "event_id": 2
+  },
+  {
+    "id": 13,
+    "name": "Hero 13",
+    "alias": "Alias13",
+    "event_id": 3
+  },
+  {
+    "id": 14,
+    "name": "Hero 14",
+    "alias": "Alias14",
+    "event_id": 4
+  },
+  {
+    "id": 15,
+    "name": "Hero 15",
+    "alias": "Alias15",
+    "event_id": 5
+  },
+  {
+    "id": 16,
+    "name": "Hero 16",
+    "alias": "Alias16",
+    "event_id": 1
+  },
+  {
+    "id": 17,
+    "name": "Hero 17",
+    "alias": "Alias17",
+    "event_id": 2
+  },
+  {
+    "id": 18,
+    "name": "Hero 18",
+    "alias": "Alias18",
+    "event_id": 3
+  },
+  {
+    "id": 19,
+    "name": "Hero 19",
+    "alias": "Alias19",
+    "event_id": 4
+  },
+  {
+    "id": 20,
+    "name": "Hero 20",
+    "alias": "Alias20",
+    "event_id": 5
+  },
+  {
+    "id": 21,
+    "name": "Hero 21",
+    "alias": "Alias21",
+    "event_id": 1
+  },
+  {
+    "id": 22,
+    "name": "Hero 22",
+    "alias": "Alias22",
+    "event_id": 2
+  },
+  {
+    "id": 23,
+    "name": "Hero 23",
+    "alias": "Alias23",
+    "event_id": 3
+  },
+  {
+    "id": 24,
+    "name": "Hero 24",
+    "alias": "Alias24",
+    "event_id": 4
+  },
+  {
+    "id": 25,
+    "name": "Hero 25",
+    "alias": "Alias25",
+    "event_id": 5
+  },
+  {
+    "id": 26,
+    "name": "Hero 26",
+    "alias": "Alias26",
+    "event_id": 1
+  },
+  {
+    "id": 27,
+    "name": "Hero 27",
+    "alias": "Alias27",
+    "event_id": 2
+  },
+  {
+    "id": 28,
+    "name": "Hero 28",
+    "alias": "Alias28",
+    "event_id": 3
+  },
+  {
+    "id": 29,
+    "name": "Hero 29",
+    "alias": "Alias29",
+    "event_id": 4
+  },
+  {
+    "id": 30,
+    "name": "Hero 30",
+    "alias": "Alias30",
+    "event_id": 5
+  },
+  {
+    "id": 31,
+    "name": "Hero 31",
+    "alias": "Alias31",
+    "event_id": 1
+  },
+  {
+    "id": 32,
+    "name": "Hero 32",
+    "alias": "Alias32",
+    "event_id": 2
+  },
+  {
+    "id": 33,
+    "name": "Hero 33",
+    "alias": "Alias33",
+    "event_id": 3
+  },
+  {
+    "id": 34,
+    "name": "Hero 34",
+    "alias": "Alias34",
+    "event_id": 4
+  },
+  {
+    "id": 35,
+    "name": "Hero 35",
+    "alias": "Alias35",
+    "event_id": 5
+  },
+  {
+    "id": 36,
+    "name": "Hero 36",
+    "alias": "Alias36",
+    "event_id": 1
+  },
+  {
+    "id": 37,
+    "name": "Hero 37",
+    "alias": "Alias37",
+    "event_id": 2
+  },
+  {
+    "id": 38,
+    "name": "Hero 38",
+    "alias": "Alias38",
+    "event_id": 3
+  },
+  {
+    "id": 39,
+    "name": "Hero 39",
+    "alias": "Alias39",
+    "event_id": 4
+  },
+  {
+    "id": 40,
+    "name": "Hero 40",
+    "alias": "Alias40",
+    "event_id": 5
+  },
+  {
+    "id": 41,
+    "name": "Hero 41",
+    "alias": "Alias41",
+    "event_id": 1
+  },
+  {
+    "id": 42,
+    "name": "Hero 42",
+    "alias": "Alias42",
+    "event_id": 2
+  },
+  {
+    "id": 43,
+    "name": "Hero 43",
+    "alias": "Alias43",
+    "event_id": 3
+  },
+  {
+    "id": 44,
+    "name": "Hero 44",
+    "alias": "Alias44",
+    "event_id": 4
+  },
+  {
+    "id": 45,
+    "name": "Hero 45",
+    "alias": "Alias45",
+    "event_id": 5
+  },
+  {
+    "id": 46,
+    "name": "Hero 46",
+    "alias": "Alias46",
+    "event_id": 1
+  },
+  {
+    "id": 47,
+    "name": "Hero 47",
+    "alias": "Alias47",
+    "event_id": 2
+  },
+  {
+    "id": 48,
+    "name": "Hero 48",
+    "alias": "Alias48",
+    "event_id": 3
+  },
+  {
+    "id": 49,
+    "name": "Hero 49",
+    "alias": "Alias49",
+    "event_id": 4
+  },
+  {
+    "id": 50,
+    "name": "Hero 50",
+    "alias": "Alias50",
+    "event_id": 5
+  }
+]

--- a/backend/seeds/events.json
+++ b/backend/seeds/events.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": 1,
+    "name": "Event 1",
+    "date": "2025-09-10",
+    "status": "open"
+  },
+  {
+    "id": 2,
+    "name": "Event 2",
+    "date": "2025-09-11",
+    "status": "closed"
+  },
+  {
+    "id": 3,
+    "name": "Event 3",
+    "date": "2025-09-12",
+    "status": "pending"
+  },
+  {
+    "id": 4,
+    "name": "Event 4",
+    "date": "2025-09-13",
+    "status": "open"
+  },
+  {
+    "id": 5,
+    "name": "Event 5",
+    "date": "2025-09-14",
+    "status": "closed"
+  }
+]

--- a/backend/seeds/matches.json
+++ b/backend/seeds/matches.json
@@ -1,0 +1,182 @@
+[
+  {
+    "id": 1,
+    "round": 1,
+    "event_id": 1,
+    "entrant1_id": 2,
+    "entrant2_id": 3,
+    "scores": "1-0",
+    "winner_id": 3
+  },
+  {
+    "id": 2,
+    "round": 2,
+    "event_id": 2,
+    "entrant1_id": 4,
+    "entrant2_id": 5,
+    "scores": "0-2",
+    "winner_id": 4
+  },
+  {
+    "id": 3,
+    "round": 3,
+    "event_id": 3,
+    "entrant1_id": 6,
+    "entrant2_id": 7,
+    "scores": "1-1",
+    "winner_id": 6
+  },
+  {
+    "id": 4,
+    "round": 4,
+    "event_id": 4,
+    "entrant1_id": 8,
+    "entrant2_id": 9,
+    "scores": "0-0",
+    "winner_id": 8
+  },
+  {
+    "id": 5,
+    "round": 5,
+    "event_id": 5,
+    "entrant1_id": 10,
+    "entrant2_id": 11,
+    "scores": "1-0",
+    "winner_id": 10
+  },
+  {
+    "id": 6,
+    "round": 1,
+    "event_id": 1,
+    "entrant1_id": 12,
+    "entrant2_id": 13,
+    "scores": "0-1",
+    "winner_id": 12
+  },
+  {
+    "id": 7,
+    "round": 2,
+    "event_id": 2,
+    "entrant1_id": 14,
+    "entrant2_id": 15,
+    "scores": "1-1",
+    "winner_id": 14
+  },
+  {
+    "id": 8,
+    "round": 3,
+    "event_id": 3,
+    "entrant1_id": 16,
+    "entrant2_id": 17,
+    "scores": "0-0",
+    "winner_id": 17
+  },
+  {
+    "id": 9,
+    "round": 4,
+    "event_id": 4,
+    "entrant1_id": 18,
+    "entrant2_id": 19,
+    "scores": "1-2",
+    "winner_id": 18
+  },
+  {
+    "id": 10,
+    "round": 5,
+    "event_id": 5,
+    "entrant1_id": 20,
+    "entrant2_id": 21,
+    "scores": "2-0",
+    "winner_id": 21
+  },
+  {
+    "id": 11,
+    "round": 1,
+    "event_id": 1,
+    "entrant1_id": 22,
+    "entrant2_id": 23,
+    "scores": "0-1",
+    "winner_id": 23
+  },
+  {
+    "id": 12,
+    "round": 2,
+    "event_id": 2,
+    "entrant1_id": 24,
+    "entrant2_id": 25,
+    "scores": "0-1",
+    "winner_id": 24
+  },
+  {
+    "id": 13,
+    "round": 3,
+    "event_id": 3,
+    "entrant1_id": 26,
+    "entrant2_id": 27,
+    "scores": "0-1",
+    "winner_id": 26
+  },
+  {
+    "id": 14,
+    "round": 4,
+    "event_id": 4,
+    "entrant1_id": 28,
+    "entrant2_id": 29,
+    "scores": "2-2",
+    "winner_id": 28
+  },
+  {
+    "id": 15,
+    "round": 5,
+    "event_id": 5,
+    "entrant1_id": 30,
+    "entrant2_id": 31,
+    "scores": "0-2",
+    "winner_id": 30
+  },
+  {
+    "id": 16,
+    "round": 1,
+    "event_id": 1,
+    "entrant1_id": 32,
+    "entrant2_id": 33,
+    "scores": "1-1",
+    "winner_id": 33
+  },
+  {
+    "id": 17,
+    "round": 2,
+    "event_id": 2,
+    "entrant1_id": 34,
+    "entrant2_id": 35,
+    "scores": "2-1",
+    "winner_id": 35
+  },
+  {
+    "id": 18,
+    "round": 3,
+    "event_id": 3,
+    "entrant1_id": 36,
+    "entrant2_id": 37,
+    "scores": "0-1",
+    "winner_id": 36
+  },
+  {
+    "id": 19,
+    "round": 4,
+    "event_id": 4,
+    "entrant1_id": 38,
+    "entrant2_id": 39,
+    "scores": "2-1",
+    "winner_id": 38
+  },
+  {
+    "id": 20,
+    "round": 5,
+    "event_id": 5,
+    "entrant1_id": 40,
+    "entrant2_id": 41,
+    "scores": "2-1",
+    "winner_id": 40
+  }
+]

--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
     "fix:backend": "black backend && flake8 backend",
     "test:backend": "pytest -q --disable-warnings",
 
-    "seed": "node backend/scripts/seed.js",
+    "db:init": "cd backend && flask db init",
     "db:clear": "python -m backend.scripts.clear_db",
+    "db:migrate": "cd backend && flask db migrate -m \"Auto migration\"",
+    "db:upgrade": "cd backend && flask db upgrade",
+    "db:seed": "cd backend && python -m backend.scripts.seed_db",
     
     "lint:frontend": "cd frontend && npm run lint",
     "format:frontend": "cd frontend && npm run format",
@@ -19,12 +22,8 @@
     "start:frontend": "cd frontend && npm start",
 
     
-    "test": "npm run test:backend && npm run test:frontend",
+    "test": "npm run test:backend && npm run test:frontend"
 
-    "db:init": "cd backend && flask db init",
-    "db:migrate": "cd backend && flask db migrate -m \"Auto migration\"",
-    "db:upgrade": "cd backend && flask db upgrade",
-    "db:seed": "cd backend && node scripts/seed.js"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "fix:backend": "black backend && flake8 backend",
     "test:backend": "pytest -q --disable-warnings",
 
+    "seed": "node backend/scripts/seed.js",
     
     "lint:frontend": "cd frontend && npm run lint",
     "format:frontend": "cd frontend && npm run format",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:backend": "pytest -q --disable-warnings",
 
     "seed": "node backend/scripts/seed.js",
+    "db:clear": "python -m backend.scripts.clear_db",
     
     "lint:frontend": "cd frontend && npm run lint",
     "format:frontend": "cd frontend && npm run format",
@@ -18,7 +19,12 @@
     "start:frontend": "cd frontend && npm start",
 
     
-    "test": "npm run test:backend && npm run test:frontend"
+    "test": "npm run test:backend && npm run test:frontend",
+
+    "db:init": "cd backend && flask db init",
+    "db:migrate": "cd backend && flask db migrate -m \"Auto migration\"",
+    "db:upgrade": "cd backend && flask db upgrade",
+    "db:seed": "cd backend && node scripts/seed.js"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
### Summary
- Implemented core SQLAlchemy models for Event, Entrant, and Match
- Added CRUD routes for events, entrants, and matches (Flask Blueprints)
- Created seed.js script and JSON seed files (events, entrants, matches)
- Updated package.json with db management scripts (init, migrate, upgrade, clear, seed)

### Testing
- All backend + frontend tests passing
- Verified event/entrant/match CRUD endpoints return expected data
- Verified seed script loads sample data

### Notes
- Seeding currently logs data counts; can extend to insert directly into DB
- db:clear wipes tables before reseeding if needed
- Can further expand seeds for pagination/stress testing