### PR TITLE
Update frontend to use new event status options

### DIFF
--- a/frontend/src/__tests__/EventDashboard.test.jsx
+++ b/frontend/src/__tests__/EventDashboard.test.jsx
@@ -29,11 +29,11 @@ describe("EventDashboard", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ id: 3, name: "Test Event", date: "2025-09-20", status: "open" }),
+        json: async () => ({ id: 3, name: "Test Event", date: "2025-09-20", status: "drafting" }),
       }) // POST
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => [{ id: 3, name: "Test Event", date: "2025-09-20", status: "open" }],
+        json: async () => [{ id: 3, name: "Test Event", date: "2025-09-20", status: "drafting" }],
       }); // GET after POST
 
     renderWithRouter(<EventDashboard />);

--- a/frontend/src/__tests__/EventDetail.test.jsx
+++ b/frontend/src/__tests__/EventDetail.test.jsx
@@ -159,35 +159,38 @@ describe("EventDetail", () => {
 describe("EventDetail - status updates", () => {
   test("updates event status via dropdown", async () => {
     global.fetch
+      // Initial GET
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
           id: 1,
           name: "Hero Cup",
           date: "2025-09-12",
-          status: "open",
+          status: "drafting",
           entrants: [],
           matches: [],
         }),
       })
+      // PUT → published
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
           id: 1,
           name: "Hero Cup",
           date: "2025-09-12",
-          status: "closed",
+          status: "published",
           entrants: [],
           matches: [],
         }),
       })
+      // Re-fetch
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
           id: 1,
           name: "Hero Cup",
           date: "2025-09-12",
-          status: "closed",
+          status: "published",
           entrants: [],
           matches: [],
         }),
@@ -196,11 +199,11 @@ describe("EventDetail - status updates", () => {
     renderWithRouter(<EventDetail />, { route: "/events/1" });
 
     expect(await screen.findByText(/Hero Cup/)).toBeInTheDocument();
-    expect(screen.getByText(/open/i)).toBeInTheDocument();
+    expect(screen.getByText(/drafting/i)).toBeInTheDocument();
 
     await userEvent.click(screen.getByLabelText(/status/i));
-    await userEvent.click(screen.getByRole("option", { name: /closed/i }));
+    await userEvent.click(screen.getByRole("option", { name: /published/i }));
 
-    expect(await screen.findByDisplayValue(/closed/i)).toBeInTheDocument();
+    expect(await screen.findByDisplayValue(/published/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/EventDashboard.jsx
+++ b/frontend/src/components/EventDashboard.jsx
@@ -29,7 +29,7 @@ function EventDashboard() {
   const [formData, setFormData] = useState({
     name: "",
     date: "",
-    status: "open",
+    status: "drafting",
   });
 
   async function fetchEvents() {
@@ -63,7 +63,7 @@ function EventDashboard() {
         throw new Error(`Failed to create event: ${errorText}`);
       }
       await fetchEvents();
-      setFormData({ name: "", date: "", status: "open" });
+      setFormData({ name: "", date: "", status: "drafting" });
     } catch (err) {
       console.error(err);
     }
@@ -109,8 +109,10 @@ function EventDashboard() {
               setFormData({ ...formData, status: e.target.value })
             }
           >
-            <MenuItem value="open">Open</MenuItem>
-            <MenuItem value="closed">Closed</MenuItem>
+            <MenuItem value="drafting">Drafting</MenuItem>
+            <MenuItem value="published">Published</MenuItem>
+            <MenuItem value="cancelled">Cancelled</MenuItem>
+            <MenuItem value="completed">Completed</MenuItem>
           </Select>
         </FormControl>
 

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -112,8 +112,10 @@ export default function EventDetail() {
             value={event.status || ""}
             onChange={handleStatusChange}
           >
-            <MenuItem value="open">Open</MenuItem>
-            <MenuItem value="closed">Closed</MenuItem>
+            <MenuItem value="drafting">Drafting</MenuItem>
+            <MenuItem value="published">Published</MenuItem>
+            <MenuItem value="cancelled">Cancelled</MenuItem>
+            <MenuItem value="completed">Completed</MenuItem>
           </Select>
         </FormControl>
       </Box>


### PR DESCRIPTION
### Summary
- Replaced legacy `open/closed` statuses with validated options: `drafting`, `published`, `cancelled`, `completed`
- Updated `EventDetail` dropdown to reflect new options
- Updated `EventDashboard` create form + list rendering
- Adjusted Jest tests (`EventDetail.test.jsx`, `EventDashboard.test.jsx`) to mock new statuses
- Ensures frontend is consistent with backend enum validation and seeded data