### PR TITLE
chore: add formatting scripts and refactor package.json for frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "@eslint/js": "^9.35.0",
     "eslint": "^8.57.1",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "eslint-plugin-react-refresh": "^0.4.20"
+    "eslint-plugin-react-refresh": "^0.4.20",
+    "prettier": "^3.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "db:seed": "PYTHONPATH=. python -m backend.scripts.seed_db",
     "db:reset": "npm run db:clear && npm run db:upgrade && npm run db:seed",
 
-    "lint:frontend": "cd frontend && npm run lint",
-    "format:frontend": "cd frontend && npm run format",
-    "fix:frontend": "cd frontend && npm run format && npm run lint",
-    "test:frontend": "cd frontend && npm test",
-    "start:frontend": "cd frontend && npm start",
+    "lint:frontend": "npm --prefix frontend run lint",
+    "format:frontend": "npm --prefix frontend run format",
+    "fix:frontend": "npm --prefix frontend run fix",
+    "test:frontend": "npm --prefix frontend run test",
+    "start:frontend": "npm --prefix frontend start",
 
     "test": "npm run test:backend && npm run test:frontend"
   },


### PR DESCRIPTION
### Summary
- Added `fix` script in `frontend/package.json` to run `prettier` + `eslint` together
- Refactored root `package.json` to use `npm --prefix frontend` instead of `cd frontend`
- Keeps root as orchestration layer for backend + frontend commands

### Changes
- `frontend/package.json`: added `"fix": "npm run format && npm run lint"`
- `root package.json`: simplified `lint:frontend`, `format:frontend`, `fix:frontend`, `test:frontend`, `start:frontend` scripts to use `--prefix`