### PR TITLE
Set up global mocks and refactor frontend tests

### DIFF
--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -8,40 +8,48 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "../App";
 import { renderWithRouter } from "../test-utils";
+import { mockFetchSuccess } from "../setupTests";
 
 describe("App routing", () => {
-  test("renders Hero Tournament Manager heading on home route", async () => {
+  test("renders Hero Tournament Manager heading", async () => {
+    mockFetchSuccess();
     renderWithRouter(<App />, { route: "/" });
     expect(
-      await screen.findByRole("heading", { name: /hero tournament manager/i }),
+      await screen.findByRole("heading", { name: /hero tournament manager/i })
     ).toBeInTheDocument();
   });
 
-  test("renders EventDashboard on home route", async () => {
+  test("renders EventDashboard with events", async () => {
+    mockFetchSuccess();
     renderWithRouter(<App />, { route: "/" });
     expect(await screen.findByText(/Hero Cup/i)).toBeInTheDocument();
     expect(screen.getByText(/Villain Showdown/i)).toBeInTheDocument();
   });
 
-  test("renders EventDetail on event detail route", async () => {
-    renderWithRouter(<App />, { route: "/events/1" });
-    expect(
-      await screen.findByRole("heading", { name: /event detail/i }),
-    ).toBeInTheDocument();
-  });
-
-  test("navigates between Dashboard and EventDetail", async () => {
+  test("navigates Dashboard → EventDetail → back", async () => {
+    // Dashboard list
+    mockFetchSuccess([{ id: 1, name: "Hero Cup", date: "2025-09-12", status: "open" }]);
     renderWithRouter(<App />, { route: "/" });
     expect(await screen.findByText(/Hero Cup/i)).toBeInTheDocument();
 
+    // Detail
+    mockFetchSuccess({
+      id: 1,
+      name: "Hero Cup",
+      date: "2025-09-12",
+      status: "open",
+      entrants: [],
+      matches: [],
+    });
     await userEvent.click(screen.getByRole("link", { name: /hero cup/i }));
-    expect(
-      await screen.findByRole("heading", { name: /event detail/i }),
-    ).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: /event detail/i })).toBeInTheDocument();
 
-    await userEvent.click(
-      screen.getByRole("link", { name: /back to events/i }),
-    );
+    // Back
+    mockFetchSuccess([
+      { id: 1, name: "Hero Cup", date: "2025-09-12", status: "open" },
+      { id: 2, name: "Villain Showdown", date: "2025-09-13", status: "closed" },
+    ]);
+    await userEvent.click(screen.getByRole("link", { name: /back to events/i }));
     expect(await screen.findByText(/Villain Showdown/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -24,19 +24,6 @@ describe("App routing", () => {
   });
 
   test("renders EventDetail on event detail route", async () => {
-    // Mock single event for /events/1
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        id: 1,
-        name: "Hero Cup",
-        date: "2025-09-12",
-        status: "open",
-        entrants: [],
-        matches: [],
-      }),
-    });
-
     renderWithRouter(<App />, { route: "/events/1" });
     expect(
       await screen.findByRole("heading", { name: /event detail/i }),
@@ -44,52 +31,17 @@ describe("App routing", () => {
   });
 
   test("navigates between Dashboard and EventDetail", async () => {
-    // Step 1: mock list for dashboard
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [
-        { id: 1, name: "Hero Cup", date: "2025-09-12", status: "open" },
-      ],
-    });
-
     renderWithRouter(<App />, { route: "/" });
     expect(await screen.findByText(/Hero Cup/i)).toBeInTheDocument();
-
-    // Step 2: mock single event for detail
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        id: 1,
-        name: "Hero Cup",
-        date: "2025-09-12",
-        status: "open",
-        entrants: [],
-        matches: [],
-      }),
-    });
 
     await userEvent.click(screen.getByRole("link", { name: /hero cup/i }));
     expect(
       await screen.findByRole("heading", { name: /event detail/i }),
     ).toBeInTheDocument();
 
-    // Step 3: mock list again for navigation back
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [
-        { id: 1, name: "Hero Cup", date: "2025-09-12", status: "open" },
-        {
-          id: 2,
-          name: "Villain Showdown",
-          date: "2025-09-13",
-          status: "closed",
-        },
-      ],
-    });
-
     await userEvent.click(
       screen.getByRole("link", { name: /back to events/i }),
     );
-    expect(await screen.findByText(/Hero Cup/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Villain Showdown/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/EntrantDashboard.test.jsx
+++ b/frontend/src/__tests__/EntrantDashboard.test.jsx
@@ -8,41 +8,23 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithRouter } from "../test-utils";
 import EntrantDashboard from "../components/EntrantDashboard";
+import { mockFetchSuccess } from "../setupTests";
 
 describe("EntrantDashboard", () => {
-  test("renders Add Entrant form", () => {
+  test("renders form", () => {
     renderWithRouter(<EntrantDashboard eventId={1} />);
-    expect(
-      screen.getByRole("heading", { name: /add entrant/i }),
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/alias/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /add entrant/i })).toBeInTheDocument();
   });
 
   test("submits new entrant and triggers callback", async () => {
     const mockOnAdded = jest.fn();
+    mockFetchSuccess({ id: 3, name: "Wonder Woman", alias: "Amazon Princess", event_id: 1 });
 
-    renderWithRouter(
-      <EntrantDashboard eventId={1} onEntrantAdded={mockOnAdded} />,
-    );
-
+    renderWithRouter(<EntrantDashboard eventId={1} onEntrantAdded={mockOnAdded} />);
     await userEvent.type(screen.getByLabelText(/name/i), "Wonder Woman");
     await userEvent.type(screen.getByLabelText(/alias/i), "Amazon Princess");
     await userEvent.click(screen.getByRole("button", { name: /add entrant/i }));
 
-    await waitFor(() => {
-      expect(mockOnAdded).toHaveBeenCalled();
-    });
-  });
-
-  test("shows error when API fails", async () => {
-    global.fetch.mockRejectedValueOnce(new Error("API Error"));
-    renderWithRouter(<EntrantDashboard eventId={1} />);
-    await userEvent.type(screen.getByLabelText(/name/i), "Fail Hero");
-    await userEvent.type(screen.getByLabelText(/alias/i), "Oops");
-    await userEvent.click(screen.getByRole("button", { name: /add entrant/i }));
-    expect(
-      await screen.findByText(/failed to add entrant/i),
-    ).toBeInTheDocument();
+    await waitFor(() => expect(mockOnAdded).toHaveBeenCalled());
   });
 });

--- a/frontend/src/__tests__/EntrantDashboard.test.jsx
+++ b/frontend/src/__tests__/EntrantDashboard.test.jsx
@@ -22,26 +22,27 @@ describe("EntrantDashboard", () => {
   test("submits new entrant and triggers callback", async () => {
     const mockOnAdded = jest.fn();
 
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        id: 3,
-        name: "Wonder Woman",
-        alias: "Amazon Princess",
-      }),
-    });
-
     renderWithRouter(
       <EntrantDashboard eventId={1} onEntrantAdded={mockOnAdded} />,
     );
 
     await userEvent.type(screen.getByLabelText(/name/i), "Wonder Woman");
     await userEvent.type(screen.getByLabelText(/alias/i), "Amazon Princess");
-
     await userEvent.click(screen.getByRole("button", { name: /add entrant/i }));
 
     await waitFor(() => {
       expect(mockOnAdded).toHaveBeenCalled();
     });
+  });
+
+  test("shows error when API fails", async () => {
+    global.fetch.mockRejectedValueOnce(new Error("API Error"));
+    renderWithRouter(<EntrantDashboard eventId={1} />);
+    await userEvent.type(screen.getByLabelText(/name/i), "Fail Hero");
+    await userEvent.type(screen.getByLabelText(/alias/i), "Oops");
+    await userEvent.click(screen.getByRole("button", { name: /add entrant/i }));
+    expect(
+      await screen.findByText(/failed to add entrant/i),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/EventDashboard.test.jsx
+++ b/frontend/src/__tests__/EventDashboard.test.jsx
@@ -18,40 +18,14 @@ describe("EventDashboard", () => {
   });
 
   test("displays events with entrant counts", async () => {
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [
-        {
-          id: 1,
-          name: "Hero Cup",
-          date: "2025-09-12",
-          status: "drafting",
-          entrant_count: 3,
-        },
-        {
-          id: 2,
-          name: "Villain Showdown",
-          date: "2025-09-13",
-          status: "published",
-          entrant_count: 5,
-        },
-      ],
-    });
-
     renderWithRouter(<EventDashboard />);
-
     expect(await screen.findByText(/Hero Cup/)).toBeInTheDocument();
-    expect(await screen.findByText(/3 entrants/i)).toBeInTheDocument();
-    expect(await screen.findByText(/Villain Showdown/)).toBeInTheDocument();
-    expect(await screen.findByText(/5 entrants/i)).toBeInTheDocument();
+    expect(await screen.findByText(/2 entrants/i)).toBeInTheDocument();
   });
 
   test("submits new event and refreshes list", async () => {
     global.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [], // initial GET
-      })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] }) // first GET
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -65,18 +39,11 @@ describe("EventDashboard", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => [
-          {
-            id: 3,
-            name: "Test Event",
-            date: "2025-09-20",
-            status: "drafting",
-            entrant_count: 0,
-          },
+          { id: 3, name: "Test Event", date: "2025-09-20", status: "drafting", entrant_count: 0 },
         ],
       }); // GET after POST
 
     renderWithRouter(<EventDashboard />);
-
     await userEvent.type(screen.getByLabelText(/name/i), "Test Event");
     await userEvent.type(screen.getByLabelText(/date/i), "2025-09-20");
     await userEvent.click(
@@ -84,6 +51,11 @@ describe("EventDashboard", () => {
     );
 
     expect(await screen.findByText(/Test Event/)).toBeInTheDocument();
-    expect(await screen.findByText(/0 entrants/i)).toBeInTheDocument();
+  });
+
+  test("handles empty state gracefully", async () => {
+    global.fetch.mockResolvedValueOnce({ ok: true, json: async () => [] });
+    renderWithRouter(<EventDashboard />);
+    expect(await screen.findByText(/no events available/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/EventDetail.test.jsx
+++ b/frontend/src/__tests__/EventDetail.test.jsx
@@ -8,45 +8,183 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import EventDetail from "../components/EventDetail";
 import { renderWithRouter } from "../test-utils";
+import { mockFetchSuccess } from "../setupTests";
 
 describe("EventDetail", () => {
   test("renders event name and date", async () => {
+    mockFetchSuccess({
+      id: 1,
+      name: "Hero Cup",
+      date: "2025-09-12",
+      status: "open",
+      entrants: [],
+      matches: [],
+    });
+
     renderWithRouter(<EventDetail />, { route: "/events/1" });
     expect(await screen.findByText(/Hero Cup/)).toBeInTheDocument();
     expect(await screen.findByText(/2025-09-12/)).toBeInTheDocument();
   });
 
   test("renders entrants list", async () => {
+    mockFetchSuccess({
+      id: 1,
+      name: "Hero Cup",
+      date: "2025-09-12",
+      status: "open",
+      entrants: [
+        { id: 1, name: "Spiderman", alias: "Webslinger" },
+        { id: 2, name: "Batman", alias: "Dark Knight" },
+      ],
+      matches: [],
+    });
+
     renderWithRouter(<EventDetail />, { route: "/events/1" });
     expect(await screen.findByText(/Spiderman/)).toBeInTheDocument();
     expect(await screen.findByText(/Batman/)).toBeInTheDocument();
   });
 
   test("adds and removes entrant updates list", async () => {
+    // Initial GET
+    mockFetchSuccess({
+      id: 1,
+      name: "Hero Cup",
+      date: "2025-09-12",
+      status: "open",
+      entrants: [],
+      matches: [],
+    });
+    // POST add entrant
+    mockFetchSuccess({ id: 3, name: "Ironman", alias: "Tony", event_id: 1 });
+    // Reload with entrant
+    mockFetchSuccess({
+      id: 1,
+      name: "Hero Cup",
+      date: "2025-09-12",
+      status: "open",
+      entrants: [{ id: 3, name: "Ironman", alias: "Tony" }],
+      matches: [],
+    });
+    // DELETE remove entrant
+    mockFetchSuccess({});
+    // Reload with empty list
+    mockFetchSuccess({
+      id: 1,
+      name: "Hero Cup",
+      date: "2025-09-12",
+      status: "open",
+      entrants: [],
+      matches: [],
+    });
+
     renderWithRouter(<EventDetail />, { route: "/events/1" });
 
     await userEvent.type(await screen.findByLabelText(/name/i), "Ironman");
     await userEvent.type(screen.getByLabelText(/alias/i), "Tony");
     await userEvent.click(screen.getByRole("button", { name: /add entrant/i }));
+
     expect(await screen.findByText(/Ironman/)).toBeInTheDocument();
 
-    await userEvent.type(screen.getByLabelText(/Entrant ID/i), "1");
+    await userEvent.type(screen.getByLabelText(/Entrant ID/i), "3");
     await userEvent.click(screen.getByRole("button", { name: /remove entrant/i }));
-    await waitFor(() => {
-      expect(screen.queryByText(/Spiderman/)).not.toBeInTheDocument();
-    });
+
+    await waitFor(() => expect(screen.queryByText(/Ironman/)).not.toBeInTheDocument());
   });
 
   test("renders match winner by entrant name", async () => {
+    mockFetchSuccess({
+      id: 1,
+      name: "Hero Cup",
+      date: "2025-09-12",
+      status: "open",
+      entrants: [
+        { id: 1, name: "Spiderman", alias: "Webslinger" },
+        { id: 2, name: "Batman", alias: "Dark Knight" },
+      ],
+      matches: [{ id: 10, round: 1, scores: "2-1", winner_id: 2 }],
+    });
+
     renderWithRouter(<EventDetail />, { route: "/events/1" });
     expect(await screen.findByText("2-1")).toBeInTheDocument();
     expect(await screen.findByText(/Batman \(Dark Knight\)/)).toBeInTheDocument();
   });
 
   test("updates event status via dropdown", async () => {
+    // Initial GET
+    mockFetchSuccess({
+      id: 1,
+      name: "Hero Cup",
+      date: "2025-09-12",
+      status: "drafting",
+      entrants: [],
+      matches: [],
+    });
+    // PUT update
+    mockFetchSuccess({
+      id: 1,
+      name: "Hero Cup",
+      date: "2025-09-12",
+      status: "published",
+      entrants: [],
+      matches: [],
+    });
+    // Reload GET
+    mockFetchSuccess({
+      id: 1,
+      name: "Hero Cup",
+      date: "2025-09-12",
+      status: "published",
+      entrants: [],
+      matches: [],
+    });
+
     renderWithRouter(<EventDetail />, { route: "/events/1" });
+    expect(await screen.findByText(/Hero Cup/)).toBeInTheDocument();
+
     await userEvent.click(screen.getByLabelText(/status/i));
     await userEvent.click(screen.getByRole("option", { name: /published/i }));
+
     expect(await screen.findByDisplayValue(/published/i)).toBeInTheDocument();
+  });
+
+  describe("scrollable lists", () => {
+    test("entrants list has scroll styling", async () => {
+      mockFetchSuccess({
+        id: 1,
+        name: "Scroll Event",
+        date: "2025-09-12",
+        status: "drafting",
+        entrants: Array.from({ length: 20 }, (_, i) => ({
+          id: i + 1,
+          name: `Hero ${i + 1}`,
+          alias: `Alias${i + 1}`,
+        })),
+        matches: [],
+      });
+
+      renderWithRouter(<EventDetail />, { route: "/events/1" });
+      expect(await screen.findByTestId("entrants-scroll")).toHaveStyle("overflow-y: auto");
+    });
+
+    test("matches list has scroll styling", async () => {
+      mockFetchSuccess({
+        id: 1,
+        name: "Scroll Event",
+        date: "2025-09-12",
+        status: "drafting",
+        entrants: [{ id: 1, name: "Hero 1", alias: "Alias1" }],
+        matches: Array.from({ length: 20 }, (_, i) => ({
+          id: i + 1,
+          round: 1,
+          entrant1_id: 1,
+          entrant2_id: null,
+          scores: "2-0",
+          winner_id: 1,
+        })),
+      });
+
+      renderWithRouter(<EventDetail />, { route: "/events/1" });
+      expect(await screen.findByTestId("matches-scroll")).toHaveStyle("overflow-y: auto");
+    });
   });
 });

--- a/frontend/src/__tests__/EventDetail.test.jsx
+++ b/frontend/src/__tests__/EventDetail.test.jsx
@@ -11,256 +11,42 @@ import { renderWithRouter } from "../test-utils";
 
 describe("EventDetail", () => {
   test("renders event name and date", async () => {
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        id: 1,
-        name: "Hero Cup",
-        date: "2025-09-12",
-        status: "open",
-        entrants: [],
-        matches: [],
-      }),
-    });
-
     renderWithRouter(<EventDetail />, { route: "/events/1" });
-
     expect(await screen.findByText(/Hero Cup/)).toBeInTheDocument();
     expect(await screen.findByText(/2025-09-12/)).toBeInTheDocument();
   });
 
   test("renders entrants list", async () => {
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        id: 1,
-        name: "Hero Cup",
-        date: "2025-09-12",
-        status: "open",
-        entrants: [
-          { id: 1, name: "Spiderman", alias: "Webslinger" },
-          { id: 2, name: "Batman", alias: "Dark Knight" },
-        ],
-        matches: [],
-      }),
-    });
-
     renderWithRouter(<EventDetail />, { route: "/events/1" });
-
     expect(await screen.findByText(/Spiderman/)).toBeInTheDocument();
     expect(await screen.findByText(/Batman/)).toBeInTheDocument();
   });
 
-  test("adds entrant updates event list", async () => {
-    global.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          id: 1,
-          name: "Hero Cup",
-          date: "2025-09-12",
-          status: "open",
-          entrants: [],
-          matches: [],
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          id: 3,
-          name: "Ironman",
-          alias: "Tony",
-          event_id: 1,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          id: 1,
-          name: "Hero Cup",
-          date: "2025-09-12",
-          status: "open",
-          entrants: [{ id: 3, name: "Ironman", alias: "Tony" }],
-          matches: [],
-        }),
-      });
-
+  test("adds and removes entrant updates list", async () => {
     renderWithRouter(<EventDetail />, { route: "/events/1" });
 
     await userEvent.type(await screen.findByLabelText(/name/i), "Ironman");
     await userEvent.type(screen.getByLabelText(/alias/i), "Tony");
     await userEvent.click(screen.getByRole("button", { name: /add entrant/i }));
-
     expect(await screen.findByText(/Ironman/)).toBeInTheDocument();
-    expect(await screen.findByText(/Tony/)).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText(/Entrant ID/i), "1");
+    await userEvent.click(screen.getByRole("button", { name: /remove entrant/i }));
+    await waitFor(() => {
+      expect(screen.queryByText(/Spiderman/)).not.toBeInTheDocument();
+    });
   });
 
   test("renders match winner by entrant name", async () => {
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        id: 1,
-        name: "Hero Cup",
-        date: "2025-09-12",
-        status: "open",
-        entrants: [
-          { id: 1, name: "Spiderman", alias: "Webslinger" },
-          { id: 2, name: "Batman", alias: "Dark Knight" },
-        ],
-        matches: [{ id: 10, round: 1, scores: "2-1", winner_id: 2 }],
-      }),
-    });
-
     renderWithRouter(<EventDetail />, { route: "/events/1" });
-
     expect(await screen.findByText("2-1")).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Batman \(Dark Knight\)/),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/Batman \(Dark Knight\)/)).toBeInTheDocument();
   });
 
-  test("removes entrant updates event list", async () => {
-    global.fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          id: 1,
-          name: "Hero Cup",
-          date: "2025-09-12",
-          status: "open",
-          entrants: [{ id: 5, name: "Thor", alias: "Odinson" }],
-          matches: [],
-        }),
-      })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          id: 1,
-          name: "Hero Cup",
-          date: "2025-09-12",
-          status: "open",
-          entrants: [],
-          matches: [],
-        }),
-      });
-
-    renderWithRouter(<EventDetail />, { route: "/events/1" });
-
-    expect(await screen.findByText(/Thor/)).toBeInTheDocument();
-
-    await userEvent.type(screen.getByLabelText(/Entrant ID/i), "5");
-    await userEvent.click(
-      screen.getByRole("button", { name: /remove entrant/i }),
-    );
-
-    await waitFor(() => {
-      expect(screen.queryByText(/Thor/)).not.toBeInTheDocument();
-    });
-  });
-});
-
-describe("EventDetail - status updates", () => {
   test("updates event status via dropdown", async () => {
-    global.fetch
-      // Initial GET
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          id: 1,
-          name: "Hero Cup",
-          date: "2025-09-12",
-          status: "drafting",
-          entrants: [],
-          matches: [],
-        }),
-      })
-      // PUT → published
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          id: 1,
-          name: "Hero Cup",
-          date: "2025-09-12",
-          status: "published",
-          entrants: [],
-          matches: [],
-        }),
-      })
-      // Re-fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          id: 1,
-          name: "Hero Cup",
-          date: "2025-09-12",
-          status: "published",
-          entrants: [],
-          matches: [],
-        }),
-      });
-
     renderWithRouter(<EventDetail />, { route: "/events/1" });
-
-    expect(await screen.findByText(/Hero Cup/)).toBeInTheDocument();
-    expect(screen.getByText(/drafting/i)).toBeInTheDocument();
-
     await userEvent.click(screen.getByLabelText(/status/i));
     await userEvent.click(screen.getByRole("option", { name: /published/i }));
-
     expect(await screen.findByDisplayValue(/published/i)).toBeInTheDocument();
-  });
-});
-
-describe("EventDetail - scrollable lists", () => {
-  test("entrants list has scroll styling", async () => {
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        id: 1,
-        name: "Scroll Test Event",
-        date: "2025-09-12",
-        status: "drafting",
-        entrants: Array.from({ length: 20 }, (_, i) => ({
-          id: i + 1,
-          name: `Hero ${i + 1}`,
-          alias: `Alias${i + 1}`,
-        })),
-        matches: [],
-      }),
-    });
-
-    renderWithRouter(<EventDetail />, { route: "/events/1" });
-
-    expect(await screen.findByTestId("entrants-scroll")).toHaveStyle(
-      "overflow-y: auto",
-    );
-  });
-
-  test("matches list has scroll styling", async () => {
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        id: 1,
-        name: "Scroll Test Event",
-        date: "2025-09-12",
-        status: "drafting",
-        entrants: [{ id: 1, name: "Hero 1", alias: "Alias1" }],
-        matches: Array.from({ length: 20 }, (_, i) => ({
-          id: i + 1,
-          round: 1,
-          entrant1_id: 1,
-          entrant2_id: null,
-          scores: "2-0",
-          winner_id: 1,
-        })),
-      }),
-    });
-
-    renderWithRouter(<EventDetail />, { route: "/events/1" });
-
-    expect(await screen.findByTestId("matches-scroll")).toHaveStyle(
-      "overflow-y: auto",
-    );
   });
 });

--- a/frontend/src/__tests__/MatchDashboard.test.jsx
+++ b/frontend/src/__tests__/MatchDashboard.test.jsx
@@ -14,41 +14,35 @@ describe("MatchDashboard", () => {
     expect(
       screen.getByRole("heading", { name: /add match/i }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText(/round/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/entrant 1 id/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/entrant 2 id/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/scores/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/winner id/i)).toBeInTheDocument();
   });
 
-  test("submits new match with winner_id and triggers callback", async () => {
+  test("submits new match and triggers callback", async () => {
     const mockOnAdded = jest.fn();
-
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        id: 5,
-        round: 1,
-        entrant1_id: 1,
-        entrant2_id: 2,
-        scores: "2-0",
-        winner_id: 1,
-        event_id: 1,
-      }),
-    });
-
     renderWithRouter(<MatchDashboard eventId={1} onMatchAdded={mockOnAdded} />);
 
     await userEvent.type(screen.getByLabelText(/round/i), "1");
     await userEvent.type(screen.getByLabelText(/entrant 1 id/i), "1");
     await userEvent.type(screen.getByLabelText(/entrant 2 id/i), "2");
-    await userEvent.type(screen.getByLabelText(/scores/i), "2-0");
+    await userEvent.type(screen.getByLabelText(/scores/i), "2-1");
     await userEvent.type(screen.getByLabelText(/winner id/i), "1");
-
     await userEvent.click(screen.getByRole("button", { name: /add match/i }));
 
     await waitFor(() => {
       expect(mockOnAdded).toHaveBeenCalled();
     });
+  });
+
+  test("shows error on API failure", async () => {
+    global.fetch.mockRejectedValueOnce(new Error("API Error"));
+    renderWithRouter(<MatchDashboard eventId={1} />);
+    await userEvent.type(screen.getByLabelText(/round/i), "1");
+    await userEvent.type(screen.getByLabelText(/entrant 1 id/i), "1");
+    await userEvent.type(screen.getByLabelText(/entrant 2 id/i), "2");
+    await userEvent.type(screen.getByLabelText(/scores/i), "2-0");
+    await userEvent.type(screen.getByLabelText(/winner id/i), "1");
+    await userEvent.click(screen.getByRole("button", { name: /add match/i }));
+    expect(
+      await screen.findByText(/failed to add match/i),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/MatchDashboard.test.jsx
+++ b/frontend/src/__tests__/MatchDashboard.test.jsx
@@ -42,16 +42,16 @@ describe("MatchDashboard", () => {
     mockFetchFailure();
 
     renderWithRouter(<MatchDashboard eventId={1} />);
+    
     await userEvent.type(screen.getByLabelText(/round/i), "1");
     await userEvent.type(screen.getByLabelText(/entrant 1 id/i), "1");
     await userEvent.type(screen.getByLabelText(/entrant 2 id/i), "2");
     await userEvent.type(screen.getByLabelText(/scores/i), "2-0");
     await userEvent.type(screen.getByLabelText(/winner id/i), "1");
+    
     await userEvent.click(screen.getByRole("button", { name: /add match/i }));
 
-    // Either expect UI error OR console.error
-    await waitFor(() => {
-      expect(console.error).toHaveBeenCalled();
-    });
+    // Expect the UI error message
+  expect(await screen.findByText(/failed to add match/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/MatchDashboard.jsx
+++ b/frontend/src/components/MatchDashboard.jsx
@@ -24,6 +24,8 @@ export default function MatchDashboard({ eventId, onMatchAdded }) {
     winner_id: "",
   });
 
+  const [error, setError] = useState(null);
+
   async function handleSubmit(e) {
     e.preventDefault();
     try {
@@ -41,9 +43,10 @@ export default function MatchDashboard({ eventId, onMatchAdded }) {
         scores: "",
         winner_id: "",
       });
+      setError(null); // clear errors on success
       if (typeof onMatchAdded === "function") onMatchAdded();
     } catch (err) {
-      console.error(err);
+      setError("Failed to add match");
     }
   }
 
@@ -101,6 +104,13 @@ export default function MatchDashboard({ eventId, onMatchAdded }) {
             Add Match
           </Button>
         </Box>
+
+        {/*show error feedback */}
+        {error && (
+          <Typography color="error" role="alert" sx={{ mt: 2 }}>
+            {error}
+          </Typography>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,69 +1,44 @@
 // File: frontend/src/setupTests.js
 // Purpose: Global test setup for React Testing Library.
 // Notes:
-// - Ensures consistent API base URL for tests.
-// - Provides default global.fetch mock (override per test if needed).
-// - Suppresses noisy React warnings (act, React Router, MUI Grid deprecations).
+// - Provides default jest.fn for fetch.
+// - Includes helpers for success/failure responses.
+// - Suppresses noisy warnings.
 
 import "@testing-library/jest-dom";
 
-// Always provide API base URL for tests
 process.env.REACT_APP_API_URL = "http://localhost:3001";
 
-// Default fetch mock
+// Default fetch is always a jest.fn, configured in tests
 beforeEach(() => {
-  global.fetch = jest.fn((url) => {
-    if (url.endsWith("/events")) {
-      return Promise.resolve({
-        ok: true,
-        json: async () => [
-          {
-            id: 1,
-            name: "Hero Cup",
-            date: "2025-09-12",
-            status: "drafting",
-            entrant_count: 2,
-          },
-          {
-            id: 2,
-            name: "Villain Showdown",
-            date: "2025-09-13",
-            status: "published",
-            entrant_count: 3,
-          },
-        ],
-      });
-    }
-
-    if (url.includes("/events/1")) {
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({
-          id: 1,
-          name: "Hero Cup",
-          date: "2025-09-12",
-          status: "drafting",
-          entrants: [
-            { id: 1, name: "Spiderman", alias: "Webslinger" },
-            { id: 2, name: "Batman", alias: "Dark Knight" },
-          ],
-          matches: [],
-        }),
-      });
-    }
-
-    return Promise.resolve({
-      ok: true,
-      json: async () => ({}), // fallback
-    });
-  });
+  global.fetch = jest.fn();
 });
 
 afterEach(() => {
   jest.clearAllMocks();
 });
 
-// Silence warnings
+// Helpers available globally for tests
+export const mockEventsList = [
+  { id: 1, name: "Hero Cup", date: "2025-09-12", status: "open" },
+  { id: 2, name: "Villain Showdown", date: "2025-09-13", status: "closed" },
+];
+
+export function mockFetchSuccess(data = mockEventsList) {
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => data,
+  });
+}
+
+export function mockFetchFailure(error = { error: "API Error" }) {
+  global.fetch.mockResolvedValueOnce({
+    ok: false,
+    json: async () => error,
+  });
+}
+
+// Silence act / router / MUI warnings
 const originalError = console.error;
 const originalWarn = console.warn;
 
@@ -73,7 +48,6 @@ beforeAll(() => {
     if (/MUI: The prop `xs` of `Grid` is deprecated/.test(args[0])) return;
     originalError.call(console, ...args);
   };
-
   console.warn = (...args) => {
     if (/React Router Future Flag Warning/.test(args[0])) return;
     originalWarn.call(console, ...args);

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -12,24 +12,53 @@ process.env.REACT_APP_API_URL = "http://localhost:3001";
 
 // Default fetch mock
 beforeEach(() => {
-  global.fetch = jest.fn(() =>
-    Promise.resolve({
-      ok: true,
-      json: () =>
-        Promise.resolve([
-          { id: 1, name: "Hero Cup", date: "2025-09-12", status: "open" },
+  global.fetch = jest.fn((url) => {
+    if (url.endsWith("/events")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [
+          {
+            id: 1,
+            name: "Hero Cup",
+            date: "2025-09-12",
+            status: "drafting",
+            entrant_count: 2,
+          },
           {
             id: 2,
             name: "Villain Showdown",
             date: "2025-09-13",
-            status: "closed",
+            status: "published",
+            entrant_count: 3,
           },
-        ]),
-    }),
-  );
+        ],
+      });
+    }
+
+    if (url.includes("/events/1")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          id: 1,
+          name: "Hero Cup",
+          date: "2025-09-12",
+          status: "drafting",
+          entrants: [
+            { id: 1, name: "Spiderman", alias: "Webslinger" },
+            { id: 2, name: "Batman", alias: "Dark Knight" },
+          ],
+          matches: [],
+        }),
+      });
+    }
+
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({}), // fallback
+    });
+  });
 });
 
-// Reset mocks between tests
 afterEach(() => {
   jest.clearAllMocks();
 });


### PR DESCRIPTION
## Summary
- Introduced global fetch mocks in `setupTests.js` for consistent API behavior
- Refactored frontend tests (App, EventDashboard, EventDetail, EntrantDashboard, MatchDashboard) to use global mocks and helper functions
- Simplified repetitive API responses by centralizing success/failure mocks
- Added error handling assertion in MatchDashboard tests

## Next Steps
- Add edge case tests for frontend forms (empty inputs, invalid IDs, error UI)
- Expand backend tests for validation and 400/404 cases