### PR TITLE
test(frontend): add edge case coverage for all components

### DIFF
--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -53,3 +53,16 @@ describe("App routing", () => {
     expect(await screen.findByText(/Villain Showdown/i)).toBeInTheDocument();
   });
 });
+
+describe("App - edge cases", () => {
+  test("shows loading and error state on failed event fetch", async () => {
+    global.fetch.mockResolvedValueOnce({ ok: false });
+    renderWithRouter(<App />, { route: "/events/999" });
+    expect(await screen.findByText(/loading event/i)).toBeInTheDocument();
+  });
+
+  test("renders Not Found on unknown route", async () => {
+    renderWithRouter(<App />, { route: "/random" });
+    expect(await screen.findByText(/not found/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/EventDashboard.test.jsx
+++ b/frontend/src/__tests__/EventDashboard.test.jsx
@@ -40,3 +40,25 @@ describe("EventDashboard", () => {
     expect(await screen.findByText(/0 entrants/i)).toBeInTheDocument();
   });
 });
+
+describe("EventDashboard - edge cases", () => {
+  test("shows placeholder when no events exist", async () => {
+    global.fetch.mockResolvedValueOnce({ ok: true, json: async () => [] });
+    renderWithRouter(<EventDashboard />);
+    expect(await screen.findByText(/no events yet/i)).toBeInTheDocument();
+  });
+
+  test("prevents event creation with missing fields", async () => {
+    renderWithRouter(<EventDashboard />);
+    await userEvent.click(screen.getByRole("button", { name: /create event/i }));
+    expect(screen.getByRole("form")).toBeInTheDocument();
+  });
+
+  test("shows error message when create event fails", async () => {
+    global.fetch.mockResolvedValueOnce({ ok: false });
+    renderWithRouter(<EventDashboard />);
+    await userEvent.type(screen.getByLabelText(/name/i), "Broken Event");
+    await userEvent.click(screen.getByRole("button", { name: /create event/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/failed to create event/i);
+  });
+});


### PR DESCRIPTION
Expanded frontend test suite with edge case coverage:
- `App`: failed fetch + unknown routes
- `EventDashboard`: empty state, invalid create, failed POST
- `EntrantDashboard`: empty form, API failure, duplicate submit
- `EventDetail`: missing event, failed removal, failed status update, TBD winner handling
- `MatchDashboard`: empty form, invalid winner ID, form reset