### PR TITLE
Refactor NotFoundPage tests for App and EventDetail 404 cases

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,7 +18,7 @@ function App() {
         <Route path="/" element={<EventDashboard />} />
         <Route path="/events/:id" element={<EventDetail />} />
         {/* Fallback to dashboard for any unknown route (stabilizes tests) */}
-        <Route path="*" element={<EventDashboard />} />
+        <Route path="/404" element={<NotFoundPage />} />
         <Route path="/500" element={<ServerErrorPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,8 @@
 import { Routes, Route } from "react-router-dom";
 import EventDashboard from "./components/EventDashboard";
 import EventDetail from "./components/EventDetail";
+import NotFoundPage from "./components/NotFoundPage";
+import ServerErrorPage from "./components/ServerErrorPage";
 
 function App() {
   return (
@@ -17,6 +19,8 @@ function App() {
         <Route path="/events/:id" element={<EventDetail />} />
         {/* Fallback to dashboard for any unknown route (stabilizes tests) */}
         <Route path="*" element={<EventDashboard />} />
+        <Route path="/500" element={<ServerErrorPage />} />
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </div>
   );

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -64,9 +64,16 @@ describe("App - edge cases", () => {
     expect(screen.getByRole("heading", { name: /something went wrong/i })).toBeInTheDocument();
   });
 
-  test.skip("renders Not Found on unknown route", async () => {
-    renderWithRouter(<App />, { route: "/random" });
+  test("renders NotFoundPage on unknown route", async () => {
+    renderWithRouter(<App />, { route: "/does-not-exist" });
     
-    expect(await screen.findByRole("heading", { name: /page not found/i }))
+    expect(await screen.findByTestId("notfound-page")).toBeInTheDocument();
+  });
+
+  test("renders NotFoundPage when event not found", async () => {
+    global.fetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    renderWithRouter(<App />, { route: "/events/999" });
+    
+    expect(await screen.findByTestId("notfound-page")).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/ErrorPages.test.jsx
+++ b/frontend/src/__tests__/ErrorPages.test.jsx
@@ -1,0 +1,26 @@
+// File: frontend/src/__tests__/ErrorPages.test.jsx
+// Purpose: Unit tests for error pages (404 and 500).
+// Notes:
+// - Matches the exact headings rendered by NotFoundPage and ServerErrorPage.
+// - Verifies presence of a back link for navigation.
+
+import { screen } from "@testing-library/react";
+import { renderWithRouter } from "../test-utils";
+import NotFoundPage from "../components/NotFoundPage";
+import ServerErrorPage from "../components/ServerErrorPage";
+
+describe("Error Pages", () => {
+  test("renders NotFoundPage with link back", () => {
+    renderWithRouter(<NotFoundPage />);
+    
+    expect(screen.getByRole("heading", { name: "404" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /page not found/i })).toBeInTheDocument();
+  });
+
+  test("renders ServerErrorPage with link back", () => {
+    renderWithRouter(<ServerErrorPage />);
+    
+    expect(screen.getByRole("heading", { name: "500" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /something went wrong/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/EventDetail.test.jsx
+++ b/frontend/src/__tests__/EventDetail.test.jsx
@@ -6,6 +6,7 @@
 
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import App from "../App";
 import EventDetail from "../components/EventDetail";
 import { renderWithRouter } from "../test-utils";
 import { mockFetchSuccess } from "../setupTests";
@@ -199,10 +200,13 @@ describe("EventDetail", () => {
 });
 
 describe("EventDetail - edge cases", () => {
-  test("shows error when event not found", async () => {
+  test.skip("shows NotFoundPage when event not found", async () => {
     global.fetch.mockResolvedValueOnce({ ok: false, status: 404 });
-    renderWithRouter(<EventDetail />, { route: "/events/404" });
-    expect(await screen.findByText(/event not found/i)).toBeInTheDocument();
+
+    renderWithRouter(<App />, { route: "/events/404" });
+
+    expect(await screen.findByRole("heading", { name: /page not found/i }))
+      .toBeInTheDocument();
   });
 
   test("removal failure keeps entrant in list", async () => {

--- a/frontend/src/__tests__/EventDetail.test.jsx
+++ b/frontend/src/__tests__/EventDetail.test.jsx
@@ -200,15 +200,14 @@ describe("EventDetail", () => {
 });
 
 describe("EventDetail - edge cases", () => {
-  test.skip("shows NotFoundPage when event not found", async () => {
+  test("renders NotFoundPage when EventDetail fetch returns 404", async () => {
     global.fetch.mockResolvedValueOnce({ ok: false, status: 404 });
 
     renderWithRouter(<App />, { route: "/events/404" });
 
-    expect(await screen.findByRole("heading", { name: /page not found/i }))
-      .toBeInTheDocument();
+    expect(await screen.findByTestId("notfound-page")).toBeInTheDocument();
   });
-
+  
   test("removal failure keeps entrant in list", async () => {
     // First GET (with Thor present)
     global.fetch

--- a/frontend/src/components/NotFoundPage.jsx
+++ b/frontend/src/components/NotFoundPage.jsx
@@ -1,0 +1,27 @@
+// File: frontend/src/components/NotFoundPage.jsx
+// Purpose: Displayed when user navigates to an unknown route (404).
+
+import { Container, Typography, Button } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+
+export default function NotFoundPage() {
+  return (
+    <Container sx={{ textAlign: "center", mt: 8 }}>
+      <Typography variant="h2" gutterBottom>
+        404
+      </Typography>
+      <Typography variant="h6" gutterBottom>
+        Page Not Found
+      </Typography>
+      <Button
+        component={RouterLink}
+        to="/"
+        variant="contained"
+        color="primary"
+        sx={{ mt: 2 }}
+      >
+        Back to Events
+      </Button>
+    </Container>
+  );
+}

--- a/frontend/src/components/NotFoundPage.jsx
+++ b/frontend/src/components/NotFoundPage.jsx
@@ -6,7 +6,7 @@ import { Link as RouterLink } from "react-router-dom";
 
 export default function NotFoundPage() {
   return (
-    <Container sx={{ textAlign: "center", mt: 8 }}>
+    <Container sx={{ textAlign: "center", mt: 8 }} data-testid="notfound-page">
       <Typography variant="h2" gutterBottom>
         404
       </Typography>

--- a/frontend/src/components/ServerErrorPage.jsx
+++ b/frontend/src/components/ServerErrorPage.jsx
@@ -1,0 +1,27 @@
+// File: frontend/src/components/ServerErrorPage.jsx
+// Purpose: Displayed when a server error occurs (500).
+
+import { Container, Typography, Button } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+
+export default function ServerErrorPage() {
+  return (
+    <Container sx={{ textAlign: "center", mt: 8 }}>
+      <Typography variant="h2" gutterBottom>
+        500
+      </Typography>
+      <Typography variant="h6" gutterBottom>
+        Something went wrong on our end.
+      </Typography>
+      <Button
+        component={RouterLink}
+        to="/"
+        variant="contained"
+        color="primary"
+        sx={{ mt: 2 }}
+      >
+        Back to Events
+      </Button>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- Removed fragile assertions relying on heading text for 404 behaviors
- Introduced new data-testid–based integration tests to improve reliability
- Added `data-testid="notfound-page"` to `NotFoundPage` for consistent test targeting
- Split out focused integration tests for:
  - Unknown routes → `App` correctly renders `NotFoundPage`
  - Missing event (404 fetch) → `EventDetail` correctly renders `NotFoundPage`