### PR TITLE
chore: resolve linting issues across backend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -25,7 +25,6 @@ def create_app():
     app.config["JWT_HEADER_TYPE"] = "Bearer"
     app.config["JWT_ALGORITHM"] = "HS256"
 
-
     db.init_app(app)
     CORS(app)  # <-- allow frontend on localhost:3000 to call
     Migrate(app, db)

--- a/backend/database.py
+++ b/backend/database.py
@@ -4,5 +4,6 @@ from flask_sqlalchemy import SQLAlchemy
 db = SQLAlchemy()
 Base = db.Model
 
+
 def init_db():
     db.create_all()

--- a/backend/models.py
+++ b/backend/models.py
@@ -4,12 +4,9 @@
 # - Enforces DB-level constraints: non-null names, valid statuses, sane match setup.
 # - Includes to_dict() methods with optional related info.
 
-from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import Enum, CheckConstraint, Column, Integer, String
 from werkzeug.security import generate_password_hash, check_password_hash
 from backend.database import Base, db
-
-# db = SQLAlchemy()
 
 # Allowed event statuses
 EVENT_STATUSES = ("drafting", "published", "cancelled", "completed")
@@ -136,8 +133,4 @@ class User(Base):
         return check_password_hash(self.password_hash, password)
 
     def to_dict(self):
-        return {
-            "id": self.id,
-            "username": self.username,
-            "email": self.email
-        }
+        return {"id": self.id, "username": self.username, "email": self.email}

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -5,15 +5,12 @@
 # - Uses JWT for token-based authentication.
 
 from flask import Blueprint, request, jsonify
-from flask_jwt_extended import (
-    create_access_token,
-    jwt_required,
-    get_jwt_identity
-)
+from flask_jwt_extended import create_access_token, jwt_required, get_jwt_identity
 from backend.database import db
 from backend.models import User
 
 auth_bp = Blueprint("auth", __name__)
+
 
 @auth_bp.route("/signup", methods=["POST"])
 def signup():

--- a/backend/scripts/seed_db.py
+++ b/backend/scripts/seed_db.py
@@ -60,7 +60,9 @@ def run():
 
         db.session.commit()
         print(
-            f"✅ Inserted {len(events)} events, {len(entrants)} entrants, {len(matches)} matches"
+            f"✅ Inserted {len(events)} events, "
+            f"{len(entrants)} entrants, "
+            f"{len(matches)} matches"
         )
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,7 +5,6 @@
 # - client: Flask test client for API requests
 # - session: SQLAlchemy session scoped to test context
 
-import os
 import pytest
 from backend.app import create_app
 from backend.models import db, Event, Entrant
@@ -16,12 +15,14 @@ from backend.database import db
 def app():
     """Create a Flask app instance for testing with in-memory DB."""
     app = create_app()
-    app.config.update({
-        "TESTING": True,
-        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
-        "SQLALCHEMY_ENGINE_OPTIONS": {"connect_args": {"check_same_thread": False}},
-        "JWT_SECRET_KEY": "test-secret",
-    })
+    app.config.update(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "SQLALCHEMY_ENGINE_OPTIONS": {"connect_args": {"check_same_thread": False}},
+            "JWT_SECRET_KEY": "test-secret",
+        }
+    )
 
     with app.app_context():
         db.create_all()
@@ -59,7 +60,9 @@ def create_event(session):
         session.add(event)
         session.commit()
         return event
+
     return _create_event
+
 
 @pytest.fixture
 def seed_event_with_entrants(session, create_event):
@@ -70,4 +73,5 @@ def seed_event_with_entrants(session, create_event):
         session.add_all([e1, e2])
         session.commit()
         return event, e1, e2
+
     return _seed_event_with_entrants

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -5,15 +5,16 @@
 # - Ensures protected routes require valid tokens
 # - Confirms logout response is returned (but JWT revocation not enforced yet)
 
-import pytest
-
 
 def test_signup_creates_user(client):
-    resp = client.post("/signup", json={
-        "username": "alice",
-        "email": "alice@example.com",
-        "password": "password123"
-    })
+    resp = client.post(
+        "/signup",
+        json={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "password123",
+        },
+    )
     assert resp.status_code == 201
     data = resp.get_json()
     assert data["username"] == "alice"
@@ -22,17 +23,15 @@ def test_signup_creates_user(client):
 
 def test_login_returns_token(client):
     # First signup
-    client.post("/signup", json={
-        "username": "bob",
-        "email": "bob@example.com",
-        "password": "secret"
-    })
+    client.post(
+        "/signup",
+        json={"username": "bob", "email": "bob@example.com", "password": "secret"},
+    )
 
     # Then login
-    resp = client.post("/login", json={
-        "email": "bob@example.com",
-        "password": "secret"
-    })
+    resp = client.post(
+        "/login", json={"email": "bob@example.com", "password": "secret"}
+    )
     assert resp.status_code == 200
     data = resp.get_json()
     token = data.get("access_token") or data.get("token")
@@ -46,15 +45,13 @@ def test_protected_route_requires_auth(client):
 
 def test_protected_route_with_auth(client):
     # signup + login
-    client.post("/signup", json={
-        "username": "cathy",
-        "email": "cathy@example.com",
-        "password": "pass"
-    })
-    login_resp = client.post("/login", json={
-        "email": "cathy@example.com",
-        "password": "pass"
-    })
+    client.post(
+        "/signup",
+        json={"username": "cathy", "email": "cathy@example.com", "password": "pass"},
+    )
+    login_resp = client.post(
+        "/login", json={"email": "cathy@example.com", "password": "pass"}
+    )
     data = login_resp.get_json()
     token = data.get("access_token") or data.get("token")
     assert token, f"Login did not return a token, got {data}"
@@ -67,15 +64,13 @@ def test_protected_route_with_auth(client):
 
 
 def test_logout_returns_ok(client):
-    client.post("/signup", json={
-        "username": "dave",
-        "email": "dave@example.com",
-        "password": "mypw"
-    })
-    login_resp = client.post("/login", json={
-        "email": "dave@example.com",
-        "password": "mypw"
-    })
+    client.post(
+        "/signup",
+        json={"username": "dave", "email": "dave@example.com", "password": "mypw"},
+    )
+    login_resp = client.post(
+        "/login", json={"email": "dave@example.com", "password": "mypw"}
+    )
     data = login_resp.get_json()
     token = data.get("access_token") or data.get("token")
     assert token, f"Login did not return a token, got {data}"

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -75,6 +75,7 @@ def test_match_cannot_have_same_entrant_for_both_slots(session):
         session.flush()  # fail on constraint
     session.rollback()
 
+
 def test_event_to_dict_with_no_entrants_or_matches(session):
     event = Event(name="Empty Cup", status="drafting")
     session.add(event)
@@ -82,12 +83,14 @@ def test_event_to_dict_with_no_entrants_or_matches(session):
     data = event.to_dict()
     assert data["entrant_count"] == 0
 
+
 def test_entrant_repr_with_no_alias(session):
     event = Event(name="Alias Cup", status="drafting")
     entrant = Entrant(name="Nameless", event=event, alias=None)
     session.add_all([event, entrant])
     session.commit()
     assert "Nameless" in repr(entrant)
+
 
 def test_match_to_dict_with_missing_winner(session):
     event = Event(name="Mystery Cup", status="drafting")

--- a/backend/tests/test_routes_entrants.py
+++ b/backend/tests/test_routes_entrants.py
@@ -55,6 +55,8 @@ def test_delete_entrant(client, create_event, session):
     response = client.delete(f"/entrants/{entrant.id}")
     assert response.status_code == 204
     assert (
-        db.session.execute(select(Entrant).filter_by(id=entrant.id)).scalar_one_or_none()
+        db.session.execute(
+            select(Entrant).filter_by(id=entrant.id)
+        ).scalar_one_or_none()
         is None
     )

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -16,7 +16,7 @@ describe("App routing", () => {
     mockFetchSuccess();
     renderWithRouter(<App />, { route: "/" });
     expect(
-      await screen.findByRole("heading", { name: /hero tournament manager/i })
+      await screen.findByRole("heading", { name: /hero tournament manager/i }),
     ).toBeInTheDocument();
   });
 
@@ -50,7 +50,7 @@ describe("App routing", () => {
 
     // 4) We should be on the detail view
     expect(
-      await screen.findByRole("heading", { name: /hero cup/i })
+      await screen.findByRole("heading", { name: /hero cup/i }),
     ).toBeInTheDocument();
   });
 });
@@ -59,21 +59,25 @@ describe("App - edge cases", () => {
   test("navigates to ServerErrorPage on 500 error", async () => {
     global.fetch.mockResolvedValueOnce({ ok: false, status: 500 });
     renderWithRouter(<App />, { route: "/events/999" });
-    
-    expect(await screen.findByRole("heading", { name: "500" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /something went wrong/i })).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole("heading", { name: "500" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /something went wrong/i }),
+    ).toBeInTheDocument();
   });
 
   test("renders NotFoundPage on unknown route", async () => {
     renderWithRouter(<App />, { route: "/does-not-exist" });
-    
+
     expect(await screen.findByTestId("notfound-page")).toBeInTheDocument();
   });
 
   test("renders NotFoundPage when event not found", async () => {
     global.fetch.mockResolvedValueOnce({ ok: false, status: 404 });
     renderWithRouter(<App />, { route: "/events/999" });
-    
+
     expect(await screen.findByTestId("notfound-page")).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/EntrantDashboard.test.jsx
+++ b/frontend/src/__tests__/EntrantDashboard.test.jsx
@@ -13,14 +13,23 @@ import { mockFetchSuccess } from "../setupTests";
 describe("EntrantDashboard", () => {
   test("renders form", () => {
     renderWithRouter(<EntrantDashboard eventId={1} />);
-    expect(screen.getByRole("heading", { name: /add entrant/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /add entrant/i }),
+    ).toBeInTheDocument();
   });
 
   test("submits new entrant and triggers callback", async () => {
     const mockOnAdded = jest.fn();
-    mockFetchSuccess({ id: 3, name: "Wonder Woman", alias: "Amazon Princess", event_id: 1 });
+    mockFetchSuccess({
+      id: 3,
+      name: "Wonder Woman",
+      alias: "Amazon Princess",
+      event_id: 1,
+    });
 
-    renderWithRouter(<EntrantDashboard eventId={1} onEntrantAdded={mockOnAdded} />);
+    renderWithRouter(
+      <EntrantDashboard eventId={1} onEntrantAdded={mockOnAdded} />,
+    );
     await userEvent.type(screen.getByLabelText(/name/i), "Wonder Woman");
     await userEvent.type(screen.getByLabelText(/alias/i), "Amazon Princess");
     await userEvent.click(screen.getByRole("button", { name: /add entrant/i }));
@@ -34,7 +43,9 @@ describe("EntrantDashboard - edge cases", () => {
     renderWithRouter(<EntrantDashboard eventId={1} />);
     await userEvent.click(screen.getByRole("button", { name: /add entrant/i }));
     // expect inline error message
-    expect(await screen.findByRole("alert")).toHaveTextContent(/failed to add entrant/i);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /failed to add entrant/i,
+    );
   });
 
   test("shows error when API call fails", async () => {
@@ -43,7 +54,9 @@ describe("EntrantDashboard - edge cases", () => {
     await userEvent.type(screen.getByLabelText(/name/i), "ErrorHero");
     await userEvent.type(screen.getByLabelText(/alias/i), "Oops");
     await userEvent.click(screen.getByRole("button", { name: /add entrant/i }));
-    expect(await screen.findByRole("alert")).toHaveTextContent(/failed to add entrant/i);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /failed to add entrant/i,
+    );
   });
 
   test("ignores duplicate submission (double click)", async () => {
@@ -53,13 +66,17 @@ describe("EntrantDashboard - edge cases", () => {
       json: async () => ({ id: 10, name: "Flash", alias: "Barry" }),
     });
 
-    renderWithRouter(<EntrantDashboard eventId={1} onEntrantAdded={mockOnAdded} />);
+    renderWithRouter(
+      <EntrantDashboard eventId={1} onEntrantAdded={mockOnAdded} />,
+    );
     await userEvent.type(screen.getByLabelText(/name/i), "Flash");
     await userEvent.type(screen.getByLabelText(/alias/i), "Barry");
-    
+
     const button = screen.getByRole("button", { name: /add entrant/i });
     await userEvent.click(button);
-    expect(await screen.findByRole("button", { name: /adding.../i })).toBeDisabled();
+    expect(
+      await screen.findByRole("button", { name: /adding.../i }),
+    ).toBeDisabled();
     expect(mockOnAdded).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/__tests__/ErrorPages.test.jsx
+++ b/frontend/src/__tests__/ErrorPages.test.jsx
@@ -12,15 +12,19 @@ import ServerErrorPage from "../components/ServerErrorPage";
 describe("Error Pages", () => {
   test("renders NotFoundPage with link back", () => {
     renderWithRouter(<NotFoundPage />);
-    
+
     expect(screen.getByRole("heading", { name: "404" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /page not found/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /page not found/i }),
+    ).toBeInTheDocument();
   });
 
   test("renders ServerErrorPage with link back", () => {
     renderWithRouter(<ServerErrorPage />);
-    
+
     expect(screen.getByRole("heading", { name: "500" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /something went wrong/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /something went wrong/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/EventDashboard.test.jsx
+++ b/frontend/src/__tests__/EventDashboard.test.jsx
@@ -14,13 +14,26 @@ describe("EventDashboard", () => {
   test("renders events heading", async () => {
     mockFetchSuccess();
     renderWithRouter(<EventDashboard />);
-    expect(await screen.findByRole("heading", { name: /events/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: /events/i }),
+    ).toBeInTheDocument();
   });
 
   test("shows entrant counts", async () => {
     mockFetchSuccess([
-      { id: 1, name: "Hero Cup", date: "2025-09-12", status: "drafting", entrants: Array(3).fill({ id: 1, name: "Hero" }) },
-      { id: 2, name: "Villain Showdown", date: "2025-09-13", entrants: Array(5).fill({ id: 2, name: "Villain" }) }
+      {
+        id: 1,
+        name: "Hero Cup",
+        date: "2025-09-12",
+        status: "drafting",
+        entrants: Array(3).fill({ id: 1, name: "Hero" }),
+      },
+      {
+        id: 2,
+        name: "Villain Showdown",
+        date: "2025-09-13",
+        entrants: Array(5).fill({ id: 2, name: "Villain" }),
+      },
     ]);
     renderWithRouter(<EventDashboard />);
     expect(await screen.findByText(/3 entrants/i)).toBeInTheDocument();
@@ -29,13 +42,29 @@ describe("EventDashboard", () => {
 
   test("submits new event", async () => {
     mockFetchSuccess([]); // initial GET
-    mockFetchSuccess({ id: 3, name: "Test Event", date: "2025-09-20", status: "drafting", entrant_count: 0 }); // POST
-    mockFetchSuccess([{ id: 3, name: "Test Event", date: "2025-09-20", status: "drafting", entrant_count: 0 }]); // reload
+    mockFetchSuccess({
+      id: 3,
+      name: "Test Event",
+      date: "2025-09-20",
+      status: "drafting",
+      entrant_count: 0,
+    }); // POST
+    mockFetchSuccess([
+      {
+        id: 3,
+        name: "Test Event",
+        date: "2025-09-20",
+        status: "drafting",
+        entrant_count: 0,
+      },
+    ]); // reload
 
     renderWithRouter(<EventDashboard />);
     await userEvent.type(screen.getByLabelText(/name/i), "Test Event");
     await userEvent.type(screen.getByLabelText(/date/i), "2025-09-20");
-    await userEvent.click(screen.getByRole("button", { name: /create event/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /create event/i }),
+    );
 
     expect(await screen.findByText(/0 entrants/i)).toBeInTheDocument();
   });
@@ -50,7 +79,9 @@ describe("EventDashboard - edge cases", () => {
 
   test("prevents event creation with missing fields", async () => {
     renderWithRouter(<EventDashboard />);
-    await userEvent.click(screen.getByRole("button", { name: /create event/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /create event/i }),
+    );
     expect(screen.getByRole("form")).toBeInTheDocument();
   });
 
@@ -61,9 +92,13 @@ describe("EventDashboard - edge cases", () => {
 
     renderWithRouter(<EventDashboard />);
     await userEvent.type(screen.getByLabelText(/event name/i), "Broken Event");
-    await userEvent.click(screen.getByRole("button", { name: /create event/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /create event/i }),
+    );
 
     const alerts = await screen.findAllByRole("alert");
-    expect(alerts.some((el) => /failed to create event/i.test(el.textContent))).toBe(true);
+    expect(
+      alerts.some((el) => /failed to create event/i.test(el.textContent)),
+    ).toBe(true);
   });
 });

--- a/frontend/src/__tests__/EventDetail.test.jsx
+++ b/frontend/src/__tests__/EventDetail.test.jsx
@@ -87,7 +87,9 @@ describe("EventDetail", () => {
     expect(await screen.findByText(/Ironman/)).toBeInTheDocument();
 
     // Remove by row-level button
-    await userEvent.click(await screen.findByRole("button", { name: /remove/i }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /remove/i }),
+    );
     await waitFor(() =>
       expect(screen.queryByText(/Ironman/)).not.toBeInTheDocument(),
     );
@@ -108,7 +110,7 @@ describe("EventDetail", () => {
 
     renderWithRouter(<EventDetail />, { route: "/events/1" });
     expect(await screen.findByText("2-1")).toBeInTheDocument();
-      expect(await screen.findByText("Batman (Dark Knight)")).toBeInTheDocument();
+    expect(await screen.findByText("Batman (Dark Knight)")).toBeInTheDocument();
   });
 
   test("updates event status via dropdown", async () => {
@@ -143,12 +145,8 @@ describe("EventDetail", () => {
     renderWithRouter(<EventDetail />, { route: "/events/1" });
     expect(await screen.findByText(/Hero Cup/)).toBeInTheDocument();
 
-    await userEvent.click(
-      screen.getByRole("combobox", { name: /status/i }),
-    );
-    await userEvent.click(
-      screen.getByRole("option", { name: /published/i }),
-    );
+    await userEvent.click(screen.getByRole("combobox", { name: /status/i }));
+    await userEvent.click(screen.getByRole("option", { name: /published/i }));
 
     expect(await screen.findByDisplayValue(/published/i)).toBeInTheDocument();
   });
@@ -169,9 +167,9 @@ describe("EventDetail", () => {
       });
 
       renderWithRouter(<EventDetail />, { route: "/events/1" });
-      expect(
-        await screen.findByTestId("entrants-scroll"),
-      ).toHaveStyle("overflow-y: auto");
+      expect(await screen.findByTestId("entrants-scroll")).toHaveStyle(
+        "overflow-y: auto",
+      );
     });
 
     test("matches list has scroll styling", async () => {
@@ -192,9 +190,9 @@ describe("EventDetail", () => {
       });
 
       renderWithRouter(<EventDetail />, { route: "/events/1" });
-      expect(
-        await screen.findByTestId("matches-scroll"),
-      ).toHaveStyle("overflow-y: auto");
+      expect(await screen.findByTestId("matches-scroll")).toHaveStyle(
+        "overflow-y: auto",
+      );
     });
   });
 });
@@ -207,7 +205,7 @@ describe("EventDetail - edge cases", () => {
 
     expect(await screen.findByTestId("notfound-page")).toBeInTheDocument();
   });
-  
+
   test("removal failure keeps entrant in list", async () => {
     // First GET (with Thor present)
     global.fetch
@@ -223,11 +221,15 @@ describe("EventDetail - edge cases", () => {
       // DELETE fails
       .mockResolvedValueOnce({ ok: false });
 
-      renderWithRouter(<EventDetail />, { route: "/events/1" });
-      await userEvent.click(await screen.findByRole("button", { name: /remove/i }));
+    renderWithRouter(<EventDetail />, { route: "/events/1" });
+    await userEvent.click(
+      await screen.findByRole("button", { name: /remove/i }),
+    );
 
-      // Component shows the error fallback, so assert the alert message rather than the row still existing
-      expect(await screen.findByRole("alert")).toHaveTextContent(/failed to remove entrant/i);
+    // Component shows the error fallback, so assert the alert message rather than the row still existing
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /failed to remove entrant/i,
+    );
   });
 
   test("status update failure reverts dropdown", async () => {
@@ -244,16 +246,20 @@ describe("EventDetail - edge cases", () => {
       })
       .mockResolvedValueOnce({ ok: false });
 
-renderWithRouter(<EventDetail />, { route: "/events/1" });
+    renderWithRouter(<EventDetail />, { route: "/events/1" });
 
-  // open the status dropdown
-  await userEvent.click(await screen.findByRole("combobox", { name: /status/i }));
+    // open the status dropdown
+    await userEvent.click(
+      await screen.findByRole("combobox", { name: /status/i }),
+    );
 
-  // choose "Published"
-  await userEvent.click(screen.getByRole("option", { name: /published/i }));
+    // choose "Published"
+    await userEvent.click(screen.getByRole("option", { name: /published/i }));
 
-  // after failure, value should be reverted back to "Drafting"
-  expect(screen.getByRole("combobox", { name: /status/i })).toHaveTextContent(/drafting/i);
+    // after failure, value should be reverted back to "Drafting"
+    expect(screen.getByRole("combobox", { name: /status/i })).toHaveTextContent(
+      /drafting/i,
+    );
   });
 
   test("renders match with TBD winner when winner_id missing", async () => {

--- a/frontend/src/__tests__/MatchDashboard.test.jsx
+++ b/frontend/src/__tests__/MatchDashboard.test.jsx
@@ -12,7 +12,9 @@ import { mockFetchSuccess, mockFetchFailure } from "../setupTests";
 describe("MatchDashboard", () => {
   test("renders Add Match form", () => {
     renderWithRouter(<MatchDashboard eventId={1} />);
-    expect(screen.getByRole("heading", { name: /add match/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /add match/i }),
+    ).toBeInTheDocument();
   });
 
   test("submits new match and triggers callback", async () => {
@@ -42,17 +44,17 @@ describe("MatchDashboard", () => {
     mockFetchFailure();
 
     renderWithRouter(<MatchDashboard eventId={1} />);
-    
+
     await userEvent.type(screen.getByLabelText(/round/i), "1");
     await userEvent.type(screen.getByLabelText(/entrant 1 id/i), "1");
     await userEvent.type(screen.getByLabelText(/entrant 2 id/i), "2");
     await userEvent.type(screen.getByLabelText(/scores/i), "2-0");
     await userEvent.type(screen.getByLabelText(/winner id/i), "1");
-    
+
     await userEvent.click(screen.getByRole("button", { name: /add match/i }));
 
     // Expect the UI error message
-  expect(await screen.findByText(/failed to add match/i)).toBeInTheDocument();
+    expect(await screen.findByText(/failed to add match/i)).toBeInTheDocument();
   });
 });
 
@@ -62,23 +64,25 @@ describe("MatchDashboard - edge cases", () => {
     await userEvent.click(screen.getByRole("button", { name: /add match/i }));
     // After clicking, button should become disabled with text "Adding..."
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: /adding.../i })).toBeDisabled()
+      expect(screen.getByRole("button", { name: /adding.../i })).toBeDisabled(),
     );
   });
-  
+
   test("shows error when winner ID does not match entrants", async () => {
     renderWithRouter(<MatchDashboard eventId={1} />);
     await userEvent.type(screen.getByLabelText(/winner id/i), "99");
     await userEvent.click(screen.getByRole("button", { name: /add match/i }));
-    expect(await screen.findByRole("alert")).toHaveTextContent(/failed to add match/i);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /failed to add match/i,
+    );
   });
-  
+
   test("clears form after successful submission", async () => {
     renderWithRouter(<MatchDashboard eventId={1} />);
     await userEvent.type(screen.getByLabelText(/round/i), "1");
     await userEvent.type(screen.getByLabelText(/scores/i), "2-0");
     await userEvent.click(screen.getByRole("button", { name: /add match/i }));
-    
+
     expect(screen.getByLabelText(/round/i)).toHaveValue("1");
     expect(screen.getByLabelText(/scores/i)).toHaveValue("2-0");
   });

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -5,7 +5,7 @@
 // - Provides inline error feedback with role="alert".
 // - Handles entrants, matches, and status updates.
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useParams, Navigate, Link as RouterLink } from "react-router-dom";
 import {
   Container,
@@ -43,7 +43,7 @@ export default function EventDetail() {
   const [tab, setTab] = useState(0);
   const [removeId, setRemoveId] = useState("");
 
-  async function fetchEvent() {
+  const fetchEvent = useCallback(async () => {
     try {
       setLoading(true);
       const res = await fetch(`${API_BASE_URL}/events/${id}`);
@@ -66,25 +66,25 @@ export default function EventDetail() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [id]);
 
   useEffect(() => {
     fetchEvent();
-  }, [id]);
+  }, [fetchEvent]);
 
-async function handleRemoveEntrant(e) {
-  e.preventDefault();
-  try {
-    const res = await fetch(`${API_BASE_URL}/entrants/${removeId}`, {
-      method: "DELETE",
-    });
-    if (!res.ok) throw new Error("Failed to remove entrant");
-    setRemoveId("");
-    fetchEvent();
-  } catch {
-    setError("Failed to remove entrant");
+  async function handleRemoveEntrant(e) {
+    e.preventDefault();
+    try {
+      const res = await fetch(`${API_BASE_URL}/entrants/${removeId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to remove entrant");
+      setRemoveId("");
+      fetchEvent();
+    } catch {
+      setError("Failed to remove entrant");
+    }
   }
-}
 
   async function handleStatusChange(newStatus) {
     if (!event) return;


### PR DESCRIPTION
## Summary
This PR cleans up linting issues flagged by `flake8` to keep the backend consistent and warning-free

## Changes
- Removed unused imports in:
  - `backend/models.py` (`SQLAlchemy`)
  - `backend/tests/conftest.py` (`os`)
  - `backend/tests/test_auth.py` (`pytest`)
- Shortened long line in `backend/scripts/seed_db.py` to comply with line length (E501)

## Notes
- No functional changes, only cleanup
- Still need to fix the duplicate `db` fixture redefinition in `conftest.py`