### PR TITLE
Fix conftest DB fixture and stabilize frontend auth tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,7 +8,6 @@
 import pytest
 from backend.app import create_app
 from backend.models import db, Event, Entrant
-from backend.database import db
 
 
 @pytest.fixture(scope="session")

--- a/frontend/src/__tests__/Auth.test.jsx
+++ b/frontend/src/__tests__/Auth.test.jsx
@@ -14,7 +14,7 @@ import ProtectedRoute from "../components/ProtectedRoute";
 
 // Mock fetch for /signup and /login
 beforeEach(() => {
-  global.fetch = jest.fn((url, options) => {
+  global.fetch = jest.fn((url) => {
     if (url.endsWith("/signup")) {
       return Promise.resolve({
         ok: true,
@@ -167,17 +167,20 @@ test("logout clears auth state (token + UI)", async () => {
   // simulate login
   await authApi.login("test@example.com", "password123");
 
-  expect(authApi.token).toBe("fake-jwt-token");
+  // wait for token set
+  await waitFor(() => {
+    expect(authApi.token).toBe("fake-jwt-token");
+  });
 
   // logout
   authApi.logout();
 
-  // wait for token clear
+  // wait for token cleared
   await waitFor(() => {
     expect(authApi.token).toBe(null);
   });
 
-  // then check UI separately
+  // check UI separately
   expect(screen.getByText(/welcome guest/i)).toBeInTheDocument();
 });
 
@@ -199,7 +202,7 @@ test("login sets user details in context", async () => {
   // login
   await authApi.login("authedUser@example.com", "password123");
 
-  // wait for token
+  // wait for token set
   await waitFor(() => {
     expect(authApi.token).toBe("fake-jwt-token");
   });


### PR DESCRIPTION
## Summary
This PR resolves backend fixture and frontend test issues flagged by lint and failing tests.

### Backend
- Removed duplicate `db` import in `backend/tests/conftest.py` (previously caused `F811` redefinition warning)
- Ensured only one `db` reference is used consistently across fixtures

### Frontend
- Refactored `Auth.test.jsx`:
  - Fixed login test to wait for token before asserting
  - Updated logout test to verify token set, cleared, and UI reset to guest
  - Simplified test flow to avoid race conditions and eslint warnings