### PR TITLE
Add Navbar with global branding and auth links

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,28 +1,39 @@
 // File: frontend/src/App.jsx
 // Purpose: Root component for React app.
 // Notes:
-// - Defines app routes only, without owning a Router.
-// - Router provided by index.jsx (prod) or test-utils (tests).
+// - Wraps app in AuthProvider for global state.
+// - Navbar provides the global top-level title and auth buttons.
+// - Each route component is responsible for its own page heading.
 
 import { Routes, Route } from "react-router-dom";
 import EventDashboard from "./components/EventDashboard";
 import EventDetail from "./components/EventDetail";
 import NotFoundPage from "./components/NotFoundPage";
 import ServerErrorPage from "./components/ServerErrorPage";
+import AuthProvider from "./context/AuthContext";
+import Navbar from "./components/Navbar";
+import LoginForm from "./components/LoginForm";
+import SignupForm from "./components/SignupForm";
 
 function App() {
   return (
-    <div>
-      <h1>Hero Tournament Manager</h1>
-      <Routes>
-        <Route path="/" element={<EventDashboard />} />
-        <Route path="/events/:id" element={<EventDetail />} />
-        {/* Fallback to dashboard for any unknown route (stabilizes tests) */}
-        <Route path="/404" element={<NotFoundPage />} />
-        <Route path="/500" element={<ServerErrorPage />} />
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
-    </div>
+    <AuthProvider>
+      <div>
+        {/* Global top header */}
+        <Navbar />
+
+        {/* Route-specific content */}
+        <Routes>
+          <Route path="/" element={<EventDashboard />} />
+          <Route path="/events/:id" element={<EventDetail />} />
+          <Route path="/login" element={<LoginForm />} />
+          <Route path="/signup" element={<SignupForm />} />
+          <Route path="/404" element={<NotFoundPage />} />
+          <Route path="/500" element={<ServerErrorPage />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </div>
+    </AuthProvider>
   );
 }
 

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -30,7 +30,7 @@ describe("App routing", () => {
   test("navigates Dashboard → EventDetail", async () => {
     // 1) Dashboard list
     mockFetchSuccess([
-      { id: 1, name: "Hero Cup", date: "2025-09-12", status: "open" },
+      { id: 1, name: "Hero Cup", date: "2025-09-12", status: "published" },
     ]);
     renderWithRouter(<App />, { route: "/" });
     expect(await screen.findByText(/Hero Cup/i)).toBeInTheDocument();
@@ -40,7 +40,7 @@ describe("App routing", () => {
       id: 1,
       name: "Hero Cup",
       date: "2025-09-12",
-      status: "open",
+      status: "published",
       entrants: [],
       matches: [],
     });

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -12,11 +12,13 @@ import { renderWithRouter } from "../test-utils";
 import { mockFetchSuccess } from "../setupTests";
 
 describe("App routing", () => {
-  test("renders Hero Tournament Manager heading", async () => {
+  test("renders Navbar with Hero Tournament Manager brand", async () => {
     mockFetchSuccess();
     renderWithRouter(<App />, { route: "/" });
+
+    // Navbar brand (Typography with Link)
     expect(
-      await screen.findByRole("heading", { name: /hero tournament manager/i }),
+      await screen.findByRole("link", { name: /hero tournament manager/i }),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/__tests__/EventDetail.test.jsx
+++ b/frontend/src/__tests__/EventDetail.test.jsx
@@ -17,7 +17,7 @@ describe("EventDetail", () => {
       id: 1,
       name: "Hero Cup",
       date: "2025-09-12",
-      status: "open",
+      status: "published",
       entrants: [],
       matches: [],
     });
@@ -32,7 +32,7 @@ describe("EventDetail", () => {
       id: 1,
       name: "Hero Cup",
       date: "2025-09-12",
-      status: "open",
+      status: "published",
       entrants: [
         { id: 1, name: "Spiderman", alias: "Webslinger" },
         { id: 2, name: "Batman", alias: "Dark Knight" },
@@ -51,7 +51,7 @@ describe("EventDetail", () => {
       id: 1,
       name: "Hero Cup",
       date: "2025-09-12",
-      status: "open",
+      status: "published",
       entrants: [],
       matches: [],
     });
@@ -62,7 +62,7 @@ describe("EventDetail", () => {
       id: 1,
       name: "Hero Cup",
       date: "2025-09-12",
-      status: "open",
+      status: "published",
       entrants: [{ id: 3, name: "Ironman", alias: "Tony" }],
       matches: [],
     });
@@ -73,7 +73,7 @@ describe("EventDetail", () => {
       id: 1,
       name: "Hero Cup",
       date: "2025-09-12",
-      status: "open",
+      status: "published",
       entrants: [],
       matches: [],
     });

--- a/frontend/src/__tests__/Navbar.test.jsx
+++ b/frontend/src/__tests__/Navbar.test.jsx
@@ -10,7 +10,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import AuthProvider, { useAuth } from "../context/AuthContext";
-import Navbar from "../components/Navbar";
+import Navbar from "./Navbar.test";
 import LoginForm from "../components/LoginForm";
 import SignupForm from "../components/SignupForm";
 

--- a/frontend/src/components/EventDashboard.jsx
+++ b/frontend/src/components/EventDashboard.jsx
@@ -86,7 +86,7 @@ export default function EventDashboard() {
   return (
     <Container maxWidth="lg" sx={{ mt: 6 }}>
       <Typography variant="h4" gutterBottom align="center">
-        Events
+        Events Dashboard
       </Typography>
 
       {/* Hero images + form */}

--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -143,8 +143,8 @@ export default function EventDetail() {
         <Button component={RouterLink} to="/" variant="outlined">
           Back to Events
         </Button>
-        <Typography variant="h4" component="h1">
-          Event Detail
+        <Typography variant="subtitle1" color="text.secondary">
+          Event Details
         </Typography>
         <Typography variant="h5" sx={{ fontWeight: "bold" }}>
           {event.name} — {event.date}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,82 @@
+// File: frontend/src/components/Navbar.jsx
+// Purpose: Global navigation bar with auth-aware UI.
+// Notes:
+// - Shows Login/Signup when logged out.
+// - Shows Welcome + Logout when logged in.
+// - Persists token handling via AuthContext.
+// - Styled with simple flexbox layout for consistency.
+
+import React from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+import { AppBar, Toolbar, Typography, Button, Box } from "@mui/material";
+
+export default function Navbar() {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate("/login");
+  };
+
+  return (
+    <AppBar position="static" color="default" elevation={1}>
+      <Toolbar sx={{ display: "flex", justifyContent: "space-between" }}>
+        {/* Left: Logo / Title */}
+        <Typography
+          variant="h6"
+          component={Link}
+          to="/"
+          sx={{
+            textDecoration: "none",
+            color: "inherit",
+            fontWeight: "bold",
+          }}
+        >
+          Hero Tournament Manager
+        </Typography>
+
+        {/* Right: Auth-aware actions */}
+        <Box sx={{ display: "flex", gap: 2 }}>
+          {!user ? (
+            <>
+              <Button
+                component={Link}
+                to="/login"
+                variant="outlined"
+                color="primary"
+              >
+                Login
+              </Button>
+              <Button
+                component={Link}
+                to="/signup"
+                variant="contained"
+                color="primary"
+              >
+                Signup
+              </Button>
+            </>
+          ) : (
+            <>
+              <Typography
+                variant="body1"
+                sx={{ alignSelf: "center", fontWeight: "500" }}
+              >
+                Welcome {user.username}
+              </Typography>
+              <Button
+                onClick={handleLogout}
+                variant="outlined"
+                color="secondary"
+              >
+                Logout
+              </Button>
+            </>
+          )}
+        </Box>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,89 @@
+// File: frontend/src/__tests__/Navbar.test.jsx
+// Purpose: Tests for Navbar auth-aware UI and routing.
+// Notes:
+// - Covers logged out UI (login/signup links).
+// - Covers logged in UI (welcome + logout).
+// - Ensures logout clears localStorage and resets user.
+// - Verifies navigation works for /, /login, and /signup.
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import AuthProvider, { useAuth } from "../context/AuthContext";
+import Navbar from "../components/Navbar";
+import LoginForm from "../components/LoginForm";
+import SignupForm from "../components/SignupForm";
+
+// Test harness page to check navigation + auth state
+function EventsPage() {
+  const { user } = useAuth();
+  return <div>Events Dashboard {user ? `(user: ${user.username})` : ""}</div>;
+}
+
+function renderWithRouter(initialEntries = ["/"]) {
+  return render(
+    <AuthProvider>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Navbar />
+        <Routes>
+          <Route path="/" element={<EventsPage />} />
+          <Route path="/login" element={<LoginForm />} />
+          <Route path="/signup" element={<SignupForm />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+}
+
+describe("Navbar", () => {
+  test("shows login/signup links when logged out", () => {
+    renderWithRouter();
+
+    expect(screen.getByRole("link", { name: /login/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /signup/i })).toBeInTheDocument();
+  });
+
+  test("navigates to login and signup pages", () => {
+    renderWithRouter();
+
+    fireEvent.click(screen.getByRole("link", { name: /login/i }));
+    expect(screen.getByRole("button", { name: /log in/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("link", { name: /signup/i }));
+    expect(
+      screen.getByRole("button", { name: /sign up/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("shows welcome + logout when logged in", async () => {
+    renderWithRouter();
+
+    // simulate login via context
+    const { login } = require("../context/AuthContext").useAuth();
+    await login("test@example.com", "password123");
+
+    expect(
+      screen.getByText(/welcome test/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /logout/i })).toBeInTheDocument();
+  });
+
+  test("logout clears token and resets user", async () => {
+    renderWithRouter();
+
+    // simulate login
+    const { login, logout } = require("../context/AuthContext").useAuth();
+    await login("test@example.com", "password123");
+
+    // confirm logged in
+    expect(localStorage.getItem("token")).toBe("fake-jwt-token");
+
+    // click logout
+    fireEvent.click(screen.getByRole("button", { name: /logout/i }));
+
+    // check state cleared
+    expect(localStorage.getItem("token")).toBeNull();
+    expect(screen.queryByText(/welcome/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /login/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,12 +1,13 @@
 // File: frontend/src/index.js
 // Purpose: Entry point for React app.
 // Notes:
-// - Mounts the App component into the root DOM node.
+// - Mounts the App component into the root DOM node with Router + AuthProvider.
 
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
+import AuthProvider from "./context/AuthContext";
 
 const container = document.getElementById("root");
 const root = createRoot(container);
@@ -14,7 +15,9 @@ const root = createRoot(container);
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
This PR introduces a global Navbar that consolidates app branding and authentication controls.

## Changes
- Added `Navbar` component with brand link ("Hero Tournament Manager")
- Navbar shows Login / Signup when logged out, and Welcome + Logout when logged in
- Wired `AuthProvider` into `index.js` so auth context is global
- Removed duplicate `<h1>` from `App.jsx`; page-level titles now reflect the current route (e.g., "Events", "Event Detail")
- Updated routing to include `/login` and `/signup`
- Tests updated/refactored for Navbar-based brand link instead of top-level heading