### PR TITLE
test(auth): align expectations with normalized JWT error handling

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -5,7 +5,6 @@
 # - Ensures protected routes require valid tokens
 # - Confirms logout response is returned (but JWT revocation not enforced yet)
 
-
 def test_signup_creates_user(client):
     resp = client.post(
         "/signup",
@@ -22,29 +21,26 @@ def test_signup_creates_user(client):
 
 
 def test_login_returns_token(client):
-    # First signup
     client.post(
         "/signup",
         json={"username": "bob", "email": "bob@example.com", "password": "secret"},
     )
-
-    # Then login
     resp = client.post(
         "/login", json={"email": "bob@example.com", "password": "secret"}
     )
     assert resp.status_code == 200
-    data = resp.get_json()
-    token = data.get("access_token") or data.get("token")
-    assert token, f"Login did not return a token, got {data}"
+    token = resp.get_json().get("access_token")
+    assert token
 
 
 def test_protected_route_requires_auth(client):
     resp = client.get("/protected")
-    assert resp.status_code in (401, 422)  # JWT will reject missing/invalid auth
+    assert resp.status_code == 401
+    # now expect "Missing Authorization Header"
+    assert resp.get_json()["error"] == "Missing Authorization Header"
 
 
 def test_protected_route_with_auth(client):
-    # signup + login
     client.post(
         "/signup",
         json={"username": "cathy", "email": "cathy@example.com", "password": "pass"},
@@ -52,14 +48,11 @@ def test_protected_route_with_auth(client):
     login_resp = client.post(
         "/login", json={"email": "cathy@example.com", "password": "pass"}
     )
-    data = login_resp.get_json()
-    token = data.get("access_token") or data.get("token")
-    assert token, f"Login did not return a token, got {data}"
-
-    # send token in header
+    token = login_resp.get_json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
+
     resp = client.get("/protected", headers=headers)
-    assert resp.status_code == 200, resp.get_json()
+    assert resp.status_code == 200
     assert "message" in resp.get_json()
 
 
@@ -71,52 +64,61 @@ def test_logout_returns_ok(client):
     login_resp = client.post(
         "/login", json={"email": "dave@example.com", "password": "mypw"}
     )
-    data = login_resp.get_json()
-    token = data.get("access_token") or data.get("token")
-    assert token, f"Login did not return a token, got {data}"
-
+    token = login_resp.get_json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
+
     logout_resp = client.delete("/logout", headers=headers)
     assert logout_resp.status_code == 200
-    assert "message" in logout_resp.get_json()
+    # normalize to "Logged out"
+    assert logout_resp.get_json()["message"] == "Logged out"
 
 
 def test_login_with_wrong_password(client, session):
-    # create user
     from backend.models import User
+
     user = User(username="edgeuser", email="edge@example.com")
     user.set_password("correctpass")
     session.add(user)
     session.commit()
 
-    resp = client.post("/login", json={"email": "edge@example.com", "password": "wrongpass"})
+    resp = client.post(
+        "/login", json={"email": "edge@example.com", "password": "wrongpass"}
+    )
     assert resp.status_code == 401
-    assert "Invalid credentials" in resp.get_json()["error"]
+    assert resp.get_json()["error"] == "Invalid credentials"
 
 
 def test_signup_with_duplicate_email(client, session):
     from backend.models import User
+
     user = User(username="dup", email="dup@example.com")
     user.set_password("pass")
     session.add(user)
     session.commit()
 
-    resp = client.post("/signup", json={"username": "dup2", "email": "dup@example.com", "password": "pass"})
+    resp = client.post(
+        "/signup",
+        json={"username": "dup2", "email": "dup@example.com", "password": "pass"},
+    )
     assert resp.status_code == 400
-    assert "Email already exists" in resp.get_json()["error"]
+    assert resp.get_json()["error"] == "Email already exists"
 
 
 def test_protected_route_with_invalid_token(client):
     headers = {"Authorization": "Bearer not.a.real.token"}
     resp = client.get("/protected", headers=headers)
-    assert resp.status_code in (401, 422)
-    msg = resp.get_json().get("msg", "").lower()
-    assert any(word in msg for word in ["invalid", "token", "segment"])
+
+    assert resp.status_code == 401
+    # now guaranteed normalized
+    assert resp.get_json()["error"] == "Invalid or expired token"
+
 
 def test_delete_event_requires_auth(client, create_event):
     event = create_event()
     resp = client.delete(f"/events/{event.id}")
     assert resp.status_code == 401
+    # same change here: missing header should match exactly
+    assert resp.get_json()["error"] == "Missing Authorization Header"
 
 
 def test_create_entrant_with_auth(client, create_event, auth_header):
@@ -127,3 +129,10 @@ def test_create_entrant_with_auth(client, create_event, auth_header):
     body = resp.get_json()
     assert body["name"] == "HeroEdge"
     assert body["alias"] == "Edgecase"
+
+
+def test_signup_missing_fields(client):
+    resp = client.post("/signup", json={"email": "no_user@example.com"})
+    assert resp.status_code == 400
+    error = resp.get_json()["error"].lower()
+    assert "missing" in error or "required" in error


### PR DESCRIPTION
## Summary
This PR updates backend auth tests to align with the new JWT error normalization in `app.py`. After adding explicit error handlers, always return a **401 Unauthorized** with consistent error messages.

## Changes
- Updated `test_protected_route_requires_auth` and `test_delete_event_requires_auth`  --> now expects `"Missing Authorization Header"` when no token is provided
- Updated `test_protected_route_with_invalid_token` --> now expects `"Invalid or expired token"` consistently for malformed/expired tokens
- Updated `test_logout_returns_ok`  --> now expects `"Logged out"` (normalized message)

## Next Steps
- Add more edge case tests for token expiry and revoked tokens (future stretch)
- Verify frontend auth flows against the normalized error messages