### PR TITLE
feat(ui): apply Material UI design to auth forms

### DIFF
--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -1,11 +1,20 @@
 // File: frontend/src/components/LoginForm.jsx
-// Purpose: Login form for existing users.
+// Purpose: Login form for existing users with Material UI styling.
 // Notes:
 // - Redirects to / after successful login.
+// - Uses MUI Container, Paper, TextField, and Button for consistent design.
 
 import React, { useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useNavigate } from "react-router-dom";
+import {
+  Container,
+  Paper,
+  Box,
+  TextField,
+  Button,
+  Typography,
+} from "@mui/material";
 
 export default function LoginForm() {
   const { login } = useAuth();
@@ -25,31 +34,44 @@ export default function LoginForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <div>
-        <label htmlFor="email">Email</label>
-        <input
-          id="email"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
-      </div>
-
-      <div>
-        <label htmlFor="password">Password</label>
-        <input
-          id="password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
-      </div>
-
-      <button type="submit">Log In</button>
-      {message && <p>{message}</p>}
-    </form>
+    <Container maxWidth="sm" sx={{ mt: 6 }}>
+      <Paper sx={{ p: 4 }}>
+        <Typography variant="h6" gutterBottom>
+          Log In
+        </Typography>
+        <Box
+          component="form"
+          onSubmit={handleSubmit}
+          sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+        >
+          <TextField
+            id="email"
+            label="Email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            fullWidth
+          />
+          <TextField
+            id="password"
+            label="Password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            fullWidth
+          />
+          <Button type="submit" variant="contained" fullWidth>
+            Log In
+          </Button>
+          {message && (
+            <Typography color="error" role="alert">
+              {message}
+            </Typography>
+          )}
+        </Box>
+      </Paper>
+    </Container>
   );
 }

--- a/frontend/src/components/SignupForm.jsx
+++ b/frontend/src/components/SignupForm.jsx
@@ -1,11 +1,20 @@
 // File: frontend/src/components/SignupForm.jsx
-// Purpose: Signup form for new users.
+// Purpose: Signup form for new users with Material UI styling.
 // Notes:
 // - Redirects to / after successful signup.
+// - Uses MUI Container, Paper, TextField, and Button for consistent design.
 
 import React, { useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useNavigate } from "react-router-dom";
+import {
+  Container,
+  Paper,
+  Box,
+  TextField,
+  Button,
+  Typography,
+} from "@mui/material";
 
 export default function SignupForm() {
   const { signup } = useAuth();
@@ -20,50 +29,59 @@ export default function SignupForm() {
     try {
       await signup(username, email, password);
       setMessage(`Signed up as ${username}`);
-      setTimeout(() => navigate("/"), 500);
-      navigate("/");
+      setTimeout(() => navigate("/"), 800);
     } catch (err) {
       setMessage(err.message);
     }
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <div>
-        <label htmlFor="username">Username</label>
-        <input
-          id="username"
-          type="text"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          required
-        />
-      </div>
-
-      <div>
-        <label htmlFor="email">Email</label>
-        <input
-          id="email"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
-      </div>
-
-      <div>
-        <label htmlFor="password">Password</label>
-        <input
-          id="password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
-      </div>
-
-      <button type="submit">Sign Up</button>
-      {message && <p>{message}</p>}
-    </form>
+    <Container maxWidth="sm" sx={{ mt: 6 }}>
+      <Paper sx={{ p: 4 }}>
+        <Typography variant="h6" gutterBottom>
+          Sign Up
+        </Typography>
+        <Box
+          component="form"
+          onSubmit={handleSubmit}
+          sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+        >
+          <TextField
+            id="username"
+            label="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+            fullWidth
+          />
+          <TextField
+            id="email"
+            label="Email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            fullWidth
+          />
+          <TextField
+            id="password"
+            label="Password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            fullWidth
+          />
+          <Button type="submit" variant="contained" fullWidth>
+            Sign Up
+          </Button>
+          {message && (
+            <Typography color="error" role="alert">
+              {message}
+            </Typography>
+          )}
+        </Box>
+      </Paper>
+    </Container>
   );
 }


### PR DESCRIPTION
### Summary
This PR updates the **Signup** and **Login** forms to use Material UI components for a consistent look and feel across the app.

### Changes
- Replaced raw `<form>` + `<input>` elements with MUI `Container`, `Paper`, `TextField`, `Button`, and `Typography`
- Added error handling feedback using `Typography color="error"`
- Centered both forms with card-style layout (`maxWidth="sm"`, `Paper` padding)
- Removed duplicate navigate call in Signup form

### Notes
- Kept forms separate (no tab toggle between login/signup)