### PR TITLE
fix(event): send correct status payload on update in EventDetail

### DIFF
--- a/frontend/src/components/EventDetail.jsx
+++ b/frontend/src/components/EventDetail.jsx
@@ -1,6 +1,7 @@
 // File: frontend/src/components/EventDetail.jsx
 // Purpose: Detailed view of a single event with entrants, matches, and status controls.
 // Notes:
+// - Fixes status update PUT request by including status in JSON body.
 // - Handles soft-deleted entrants by showing "Dropped" instead of crashing.
 // - Provides inline error feedback with role="alert".
 // - Redirects to /404 or /500 for test-friendly error handling.
@@ -79,13 +80,16 @@ export default function EventDetail() {
     }
   }
 
-  async function handleStatusChange(newStatus) {
+  async function handleStatusChange(e) {
     if (!event) return;
+    const newStatus = e.target.value;
     const prevStatus = event.status;
+
     try {
       await apiFetch(`/events/${id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
       });
       await fetchEvent();
     } catch {


### PR DESCRIPTION
## Summary
This PR fixes the event status update flow, which previously failed with a 400 error because the backend received no JSON payload; status changes are now persisted correctly with proper request bodies.

## Changes
- **Frontend**
  - `EventDetail.jsx`: 
    - `handleStatusChange` now sends `body: { status: newStatus }` with PUT request
    - Preserves previous status on failure for smoother UX
    - Select dropdown still displays current event status reliably

## Notes
- Verified status transitions across all valid states (`drafting`, `published`, `cancelled`, `completed`)
- Error messaging and rollback behavior works when API call fails